### PR TITLE
added basic travis ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: elixir
+elixir: '1.5'
+otp_release: '20.0'
+script:
+- mix test
+- mix credo --strict

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RIG - Reactive Interaction Gateway
 
+[![Build Status](https://travis-ci.org/Accenture/reactive-interaction-gateway.svg?branch=master)](https://travis-ci.org/Accenture/reactive-interaction-gateway)
+
 RIG is a scalable, open source gateway to your microservices. It solves the problem of
 connection state (which users are online currently, with which devices), which allows your
 microservices to be stateless. Pushing arbitrary messages to all connected frontends of a


### PR DESCRIPTION
I've created a simple Travis CI setup to address #7.

Nothing fancy it'll just run tests and lints (as described in contributing document).
It also adds the build status badge to README.