### PR TITLE
disabled Design.AliasUsage credo rule

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -57,7 +57,7 @@
 
         # For some checks, like AliasUsage, you can only customize the priority
         # Priority values are: `low, normal, high, higher`
-        {Credo.Check.Design.AliasUsage, priority: :low},
+        {Credo.Check.Design.AliasUsage, false},
 
         # For others you can set parameters
 


### PR DESCRIPTION
The aliasing rule (which we decided not to use) caused credo in strict mode to fail (low priority warnings).
This should fix the linting phase.