### PR TITLE
Maintain a changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+[Unreleased]
+
+- Changed
+  - [Config] Increase default rate limits - [#16](https://github.com/Accenture/reactive-interaction-gateway/pull/16)
+  - [Kafka] Make producing of Kafka messages in proxy optional (and turned off by default) - [#21](https://github.com/Accenture/reactive-interaction-gateway/pull/21)
+
+- Added
+  - [Deploy] Basic Travis configuration - [#17](https://github.com/Accenture/reactive-interaction-gateway/pull/17)
+  - [Docs] Configuration ADR document - [#19](https://github.com/Accenture/reactive-interaction-gateway/pull/19)
+  - [Docs] Websocket and SSE channels example - [#22](https://github.com/Accenture/reactive-interaction-gateway/pull/22)
+  - [Deploy] Maintain changelog file - [#25](https://github.com/Accenture/reactive-interaction-gateway/pull/25)
+
+- Fixed
+  - [Config] Fix Travis by disabling credo rule `Design.AliasUsage` - [#18](https://github.com/Accenture/reactive-interaction-gateway/pull/18)
+
+## v1.0.0 (November 9, 2017)
+
+- Changed
+  - [Config] Update configuration to be able to modify almost anything by environment variables on RIG start - [#5](https://github.com/Accenture/reactive-interaction-gateway/pull/5)
+  - [Deploy] Rework Dockerfile to use multistage approach for building RIG Docker image - [#9](https://github.com/Accenture/reactive-interaction-gateway/pull/9)
+  - [Config] Update entire code base to use `rig` keyword - [#13](https://github.com/Accenture/reactive-interaction-gateway/pull/13)
+
+- Added
+  - [Docs] Add `mix docs` script to generate documentation of code base - [#6](https://github.com/Accenture/reactive-interaction-gateway/pull/6)
+  - [Docs] Add ethics documentation such as code of conduct and contribution guidelines - [#6](https://github.com/Accenture/reactive-interaction-gateway/pull/6)
+
+- Removed
+  - [Config] Disable Origin checking - [#12](https://github.com/Accenture/reactive-interaction-gateway/pull/12)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ We follow the [standard GitHub workflow](https://guides.github.com/introduction/
 Before submitting a PR,
 - please write tests,
 - make sure you run all tests and check the linter (credo) for warnings.
+- update `CHANGELOG.md` file with your current change in form of `[Type of change e.g. Config, Kafka, .etc] Short description what it is all about - [#PR-ID-NUMBER](link to pull request)`, please put your change under suitable section - changed, added, fixed, removed, deprecated
 
 An overview of the directory structure:
 - `lib/rig`

--- a/doc/architecture/decisions/0005-maintain-changelog.md
+++ b/doc/architecture/decisions/0005-maintain-changelog.md
@@ -1,0 +1,19 @@
+# 5. Maintain changelog
+
+Date: 14/12/2017
+
+## Status
+
+Accepted
+
+## Context
+
+We need to track what changes have been made to RIG and make it clear to everyone. It should also help with identifying of issues that may be caused by changes in the past.
+
+## Decision
+
+We decided to use `CHANGELOG.md` to have it as a single source of truth to what happened in RIG. Every submitted Pull Request will contain update to this file as well. By this everyone can clearly see which version has which features or fixes.
+
+## Consequences
+
+Every contributor submitting Pull Request has to also update `CHANGELOG.md` file and keep everything up to date. Update has to be done in form of `[Type of change e.g. Config, Kafka, .etc] Short description what it is all about - [#PR-ID-NUMBER](link to pull request)`, please put your change under suitable section - changed, added, fixed, removed, deprecated

--- a/mix.exs
+++ b/mix.exs
@@ -101,9 +101,11 @@ defmodule Rig.Mixfile do
         "doc/configuration.md": [title: "Configuration"],
         "CODE_OF_CONDUCT.md": [title: "Code of Conduct"],
         "CONTRIBUTING.md": [title: "Contributing"],
+        "CHANGELOG.md": [title: "Changelog"],
         "doc/architecture/decisions/0001-record-architecture-decisions.md": [group: "Architecture Decisions"],
         "doc/architecture/decisions/0002-don-t-check-for-functionclauseerror-in-tests.md": [group: "Architecture Decisions"],
         "doc/architecture/decisions/0004-use-rig-config-for-global-configuration.md": [group: "Architecture Decisions"],
+        "doc/architecture/decisions/0005-maintain-changelog.md": [group: "Architecture Decisions"],
       ],
       main: "README",
     ]


### PR DESCRIPTION
## Changes

- added `CHANGELOG.md` and related ADR
- filled `CHANGELOG.md` with all recent changes
- `mix docs` should work and generate new content

## Notes

- once we'll have umbrella setup we can add `###` headers and differentiate between direct changes in given sub application
e.g.
```
### Proxy

- Changed
  - ...

- Fixed
  - ...

### Monitoring

- Changed
  - ...
```

Decided to use PR numbers/links in notes. **Downside** is that you have to either guess (look at most recent PR and increment that by 1) your PR number or do one more commit after PR submit. But I think it's **better** to be redirected to PR and see code immediately rather than be redirected to issue and go through possibly long page to find out proper PR change.