### PR TITLE
Env var for internal-API's port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Fixed
   - [Inbound] Make presence channel respect `JWT_USER_FIELD` setting (currently hardcoded to "username")
+  - [Inbound] Set proper environment variable for Phoenix server `PORT_INBOUND` - [#]()
+  - [API] Set proper environment variable for Phoenix server `PORT_API` - [#]()
 
 - Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
 
 - Fixed
   - [Inbound] Make presence channel respect `JWT_USER_FIELD` setting (currently hardcoded to "username")
-  - [Inbound] Set proper environment variable for Phoenix server `PORT_INBOUND` - [#]()
-  - [API] Set proper environment variable for Phoenix server `PORT_API` - [#]()
+  - [Inbound] Set proper environment variable for Phoenix server `PORT_INBOUND` - [#38](https://github.com/Accenture/reactive-interaction-gateway/pull/38)
+  - [API] Set proper environment variable for Phoenix server `PORT_API` - [#38](https://github.com/Accenture/reactive-interaction-gateway/pull/38)
 
 - Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
 
 - Fixed
   - [Inbound] Make presence channel respect `JWT_USER_FIELD` setting (currently hardcoded to "username")
-  - [Inbound] Set proper environment variable for Phoenix server `PORT_INBOUND` - [#38](https://github.com/Accenture/reactive-interaction-gateway/pull/38)
-  - [API] Set proper environment variable for Phoenix server `PORT_API` - [#38](https://github.com/Accenture/reactive-interaction-gateway/pull/38)
+  - [Inbound] Set proper environment variable for Phoenix server `INBOUND_PORT` - [#38](https://github.com/Accenture/reactive-interaction-gateway/pull/38)
+  - [API] Set proper environment variable for Phoenix server `API_PORT` - [#38](https://github.com/Accenture/reactive-interaction-gateway/pull/38)
 
 - Deprecated
 

--- a/apps/rig_api/config/config.exs
+++ b/apps/rig_api/config/config.exs
@@ -18,7 +18,7 @@ config :rig_api, RigApi.Endpoint,
     host: {:system, "HOST", "localhost"}
   ],
   http: [
-    port: {:system, :integer, "PORT_API", 4010}
+    port: {:system, :integer, "API_PORT", 4010}
   ],
   render_errors: [view: RigApi.ErrorView, accepts: ~w(json)],
   pubsub: [name: Rig.PubSub]

--- a/apps/rig_api/config/config.exs
+++ b/apps/rig_api/config/config.exs
@@ -18,7 +18,7 @@ config :rig_api, RigApi.Endpoint,
     host: {:system, "HOST", "localhost"}
   ],
   http: [
-    port: {:system, :integer, "PORT", 4010}
+    port: {:system, :integer, "PORT_API", 4010}
   ],
   render_errors: [view: RigApi.ErrorView, accepts: ~w(json)],
   pubsub: [name: Rig.PubSub]

--- a/apps/rig_api/config/test.exs
+++ b/apps/rig_api/config/test.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :rig_api, RigApi.Endpoint,
   env: :test,
-  http: [port: System.get_env("PORT") || 4011],
+  http: [port: System.get_env("PORT_API") || 4011],
   server: false
 
 config :rig, RigApi.ApisController,

--- a/apps/rig_api/config/test.exs
+++ b/apps/rig_api/config/test.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :rig_api, RigApi.Endpoint,
   env: :test,
-  http: [port: System.get_env("PORT_API") || 4011],
+  http: [port: System.get_env("API_PORT") || 4011],
   server: false
 
 config :rig, RigApi.ApisController,

--- a/apps/rig_inbound_gateway/config/config.exs
+++ b/apps/rig_inbound_gateway/config/config.exs
@@ -22,7 +22,7 @@ config :rig_inbound_gateway, RigInboundGatewayWeb.Endpoint,
     host: {:system, "HOST", "localhost"}
   ],
   http: [
-    port: {:system, :integer, "PORT_INBOUND", 4000}
+    port: {:system, :integer, "INBOUND_PORT", 4000}
   ],
   render_errors: [view: RigInboundGatewayWeb.ErrorView, accepts: ~w(html json xml)],
   pubsub: [name: Rig.PubSub]

--- a/apps/rig_inbound_gateway/config/config.exs
+++ b/apps/rig_inbound_gateway/config/config.exs
@@ -22,7 +22,7 @@ config :rig_inbound_gateway, RigInboundGatewayWeb.Endpoint,
     host: {:system, "HOST", "localhost"}
   ],
   http: [
-    port: {:system, :integer, "PORT", 4000}
+    port: {:system, :integer, "PORT_INBOUND", 4000}
   ],
   render_errors: [view: RigInboundGatewayWeb.ErrorView, accepts: ~w(html json xml)],
   pubsub: [name: Rig.PubSub]

--- a/apps/rig_inbound_gateway/config/test.exs
+++ b/apps/rig_inbound_gateway/config/test.exs
@@ -4,7 +4,7 @@ use Mix.Config
 # you can enable the server option below.
 config :rig, RigInboundGatewayWeb.Endpoint,
   env: :test,
-  http: [port: System.get_env("PORT") || 4001],
+  http: [port: System.get_env("PORT_INBOUND") || 4001],
   server: false
 
 # Print only warnings and errors during test

--- a/apps/rig_inbound_gateway/config/test.exs
+++ b/apps/rig_inbound_gateway/config/test.exs
@@ -4,7 +4,7 @@ use Mix.Config
 # you can enable the server option below.
 config :rig, RigInboundGatewayWeb.Endpoint,
   env: :test,
-  http: [port: System.get_env("PORT_INBOUND") || 4001],
+  http: [port: System.get_env("INBOUND_PORT") || 4001],
   server: false
 
 # Print only warnings and errors during test


### PR DESCRIPTION
- fixed inbound gateway and api to have proper env vars for ports

**Test**:

`API_PORT=4444 INBOUND_PORT=5555 mix phx.server` should set proper ports

Closes #32 