### PR TITLE
Detailed guide for env vars configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   - [Deploy] Kubernetes deployment configuration file - [#29](https://github.com/Accenture/reactive-interaction-gateway/pull/29)
   - [Misc] Smoke tests setup and test cases for API Proxy and Kafka + Phoenix messaging - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
   - [Outbound] Kafka consumer ready check utility function - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
-  - [Docs] List of all environment variables possible to set in `guides/operator-guide.md` - [#48](https://github.com/Accenture/reactive-interaction-gateway/pull/48)
+  - [Docs] List of all environment variables possible to set in `guides/operator-guide.md` - [#36](https://github.com/Accenture/reactive-interaction-gateway/pull/36)
 
 - Fixed
   - [Inbound] Make presence channel respect `JWT_USER_FIELD` setting (currently hardcoded to "username")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - [Deploy] Kubernetes deployment configuration file - [#29](https://github.com/Accenture/reactive-interaction-gateway/pull/29)
   - [Misc] Smoke tests setup and test cases for API Proxy and Kafka + Phoenix messaging - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
   - [Outbound] Kafka consumer ready check utility function - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
+  - [Docs] List of all environment variables possible to set in `guides/operator-guide.md` - [#48](https://github.com/Accenture/reactive-interaction-gateway/pull/48)
 
 - Fixed
   - [Inbound] Make presence channel respect `JWT_USER_FIELD` setting (currently hardcoded to "username")

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ It should be easy to integrate RIG into your current architecture. Check out
 
 Currently we support two ways to deploy RIG: using Docker and using classical Erlang releases. Docker may be simpler for most use cases, but Erlang releases allow for hot code reloading.
 
+You can find list of all environment variables in [operator guide](guides/operator-guide.md).
+
 ### Deployment using Docker
 
 ```bash

--- a/apps/rig/lib/mix/tasks/update_docs.ex
+++ b/apps/rig/lib/mix/tasks/update_docs.ex
@@ -126,7 +126,7 @@ defmodule Mix.Tasks.UpdateDocs do
 
   def log_documented_but_missing_vars({table_keyset, env_keyset}) do
     @erlang_envs
-    |> MapSet.new
+    |> MapSet.new()
     |> MapSet.difference(table_keyset)
     |> MapSet.difference(env_keyset)
     |> Enum.each(fn key ->
@@ -156,11 +156,14 @@ defmodule Mix.Tasks.UpdateDocs do
   end
 
   defp nested_envs(envs) do
-    {flat_env, list_env} = Enum.split_with(envs, fn {_, _} -> true
-                                                    _ -> false
-    end)
+    {flat_env, list_env} =
+      Enum.split_with(envs, fn
+        {_, _} -> true
+        _ -> false
+      end)
+
     list_env
-    |> List.flatten
+    |> List.flatten()
     |> Enum.concat(flat_env)
     |> Enum.reject(&is_nil/1)
   end
@@ -169,14 +172,21 @@ defmodule Mix.Tasks.UpdateDocs do
     env
     |> Stream.flat_map(fn {_mod, kwlist} -> kwlist end)
     |> Stream.map(fn
-      {_, {:system, key, val}} -> {key, val}
-      {_, {:system, _, key, val}} -> {key, val}
+      {_, {:system, key, val}} ->
+        {key, val}
+
+      {_, {:system, _, key, val}} ->
+        {key, val}
+
       {_, list_env = [_ | _]} ->
-        Enum.map(list_env, fn {_, {:system, key, val}} -> {key, val}
-                              {_, {:system, _, key, val}} -> {key, val}
-                              _ -> nil
+        Enum.map(list_env, fn
+          {_, {:system, key, val}} -> {key, val}
+          {_, {:system, _, key, val}} -> {key, val}
+          _ -> nil
         end)
-      _ -> nil
+
+      _ ->
+        nil
     end)
     |> Stream.reject(&is_nil/1)
     |> Enum.to_list()

--- a/config/config.exs
+++ b/config/config.exs
@@ -54,7 +54,8 @@ config :rig, RigAuth.Jwt.Utils,
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 config :rig, Rig.Discovery,
-  discovery_type: nil
+  discovery_type: {:system, "DISCOVERY_TYPE", nil},
+  dns_name: {:system, "DNS_NAME", "localhost"}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,11 +2,3 @@ use Mix.Config
 
 # Do not print debug messages in production
 config :logger, level: :warn
-
-# --------------------------------------
-# Peerage
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-config :rig, Rig.Discovery,
-  discovery_type: {:system, "DISCOVERY_TYPE", nil},
-  dns_name: {:system, "DNS_NAME", "localhost"}

--- a/guides/operator-guide.md
+++ b/guides/operator-guide.md
@@ -26,7 +26,7 @@ Variable | Description | Default
 `KAFKA_SOURCE_TOPICS` | List of Kafka topics RIG will consume, delimited by comma. | ["rig"]
 `MESSAGE_USER_FIELD` | (Outbound) messages are expected to be in JSON format. For routing the message to a specific user, RIG expects the user's ID to be present in such a JSON message. The corresponding JSON field is defined by `MESSAGE_USER_FIELD`. | "user"
 `NODE_COOKIE` | Erlang cookie used in distributed mode, so nodes in cluster can communicate between each other. | nil
-`NODE_HOST` | Erlang hostname for given node thanks to which is routable by other nodes in cluster. | nil
+`NODE_HOST` | Erlang hostname for given node, used to build Erlang long-name `rig@NODE_HOST`. This value is used by Erlang's distributed mode, so nodes can see each other. | nil
 `PRIVILEGED_ROLES` | User roles that are able to subscribe to messages of any user. You can specify multiple roles delimited by comma. | []
 `PROXY_CONFIG_FILE` | Configuration JSON file with initial API definition for API Proxy. Expected path is `proxy/your_json_file.json`. | nil
 `RATE_LIMIT_AVG_RATE_PER_SEC` | The permitted average amount of requests per second. | 10000

--- a/guides/operator-guide.md
+++ b/guides/operator-guide.md
@@ -10,9 +10,31 @@ RIG uses environment variables for most of its configuration -- they're listed i
 
 Variable | Description | Default
 -------- | ----------- | -------
+`API_PORT` | Port at which RIG exposes internal APIs such as API Proxy management or user connections management. | 4010
+`DISCOVERY_TYPE` | Type of discovery used in distributed mode. If not set discovery is not used. Available options: `dns`. | nil
+`DNS_NAME` | Address where RIG will do DNS discovery for Node host addresses. | "localhost"
+`HOST` | Hostname for Phoenix endpoints (HTTP communication). | "localhost"
+`INBOUND_PORT` | Port at which RIG exposes proxy and websocket/sse communication. | 4000
+`JWT_BLACKLIST_DEFAULT_EXPIRY_HOURS` | Default expiration time in hours for blacklisted JWTs. Used if JWT doesn't have an expiration time in claims. | 1
+`JWT_ROLES_FIELD` | Key in JWT claims under which roles are set for each user. | "roles"
 `JWT_SECRET_KEY` | The secret key used to sign and verify the JSON web tokens. | ""
 `JWT_USER_FIELD` | The JSON web token as sent by the front-ends should contain the user ID, in the same format used by the back-ends in the messages they send towards the user. `JWT_USER_FIELD` is the name of that user ID field in the JWT. For the corresponding field used in outbound messages, see `MESSAGE_USER_FIELD`. | "user"
-`MESSAGE_USER_FIELD` | (Outbound) messages are expected to be in JSON format. For routing the message to a specific user, RIG expects the user's ID to be present in such a JSON message. The corresponding JSON field is defined by `MESSAGE_USER_FIELD`. | "user"
+`KAFKA_CONSUMER_GROUP` | Consumer group name for Kafka. | "rig-consumer-group"
 `KAFKA_ENABLED` | If enabled, RIG will consume messages from a Kafka broker using the configured broker and topic(s). | false
+`KAFKA_HOSTS` | List of Kafka brokers RIG should connect to, delimited by comma. Usually it's enough to specify one broker and RIG will auto-discover rest of the Kafka cluster. | ["localhost:9092"]
+`KAFKA_LOG_TOPIC` | Kafka topic for producer used to log HTTP requests going through RIG's API Proxy. | "rig-request-log"
+`KAFKA_SOURCE_TOPICS` | List of Kafka topics RIG will consume, delimited by comma. | ["rig"]
+`MESSAGE_USER_FIELD` | (Outbound) messages are expected to be in JSON format. For routing the message to a specific user, RIG expects the user's ID to be present in such a JSON message. The corresponding JSON field is defined by `MESSAGE_USER_FIELD`. | "user"
+`NODE_COOKIE` | Erlang cookie used in distributed mode, so nodes in cluster can communicate between each other. | nil
+`NODE_HOST` | Erlang hostname for given node thanks to which is routable by other nodes in cluster. | nil
+`PRIVILEGED_ROLES` | User roles that are able to subscribe to messages of any user. You can specify multiple roles delimited by comma. | []
+`PROXY_CONFIG_FILE` | Configuration JSON file with initial API definition for API Proxy. Expected path is `proxy/your_json_file.json`. | nil
+`RATE_LIMIT_AVG_RATE_PER_SEC` | The permitted average amount of requests per second. | 10000
+`RATE_LIMIT_BURST_SIZE` | The permitted peak amount of requests. | 5000
+`RATE_LIMIT_ENABLED` | Enables/disables rate limiting globally. | false
+`RATE_LIMIT_PER_IP` | If true, the remote IP is taken into account, otherwise the limits are per endpoint only. | true
+`RATE_LIMIT_SWEEP_INTERVAL_MS` | Garbage collector interval. If set to zero, Garbage collector is disabled. | 5000
+`REQUEST_LOG` | Type of loggers to use to log requests processed by API Proxy, delimited by comma. | []
+`SESSION_ROLE` | Type of users that are visible to the outside world (possible to list). Only users with these roles will be listed. Possible roles are listed in `JWT_ROLES_FIELD`. Define as strings, separated by comma. | "user"
 
 .


### PR DESCRIPTION
- updated operator guide with all environment variables => sorted alphabetically
- updated `update_docs.ex` to be able to work with nested env vars such as PORTs for Phoenix Endpoints.
- updated readme to point to operator guide

**Test:**

- check readme => should link you to operator's guide
- check env vars description
- `mix compile` shouldn't throw any warning regarding undocumented env var, Erlang env vars are skipped since they are used in prod not directly by Elixir

Closes #36 