### PR TITLE
Possibility to change LOG LEVEL with env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   - [Deploy] Kubernetes deployment configuration file - [#29](https://github.com/Accenture/reactive-interaction-gateway/pull/29)
   - [Misc] Smoke tests setup and test cases for API Proxy and Kafka + Phoenix messaging - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
   - [Outbound] Kafka consumer ready check utility function - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
-  - [Rig] Possibility to set logging level with env var `LOG_LEVEL` globally for RIG - [#49](https://github.com/Accenture/reactive-interaction-gateway/pull/49)
+  - [Rig] Possibility to set logging level with env var `LOG_LEVEL` globally for RIG - [#50](https://github.com/Accenture/reactive-interaction-gateway/pull/50)
 
 - Fixed
   - [Inbound] Make presence channel respect `JWT_USER_FIELD` setting (currently hardcoded to "username")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   - [Deploy] Kubernetes deployment configuration file - [#29](https://github.com/Accenture/reactive-interaction-gateway/pull/29)
   - [Misc] Smoke tests setup and test cases for API Proxy and Kafka + Phoenix messaging - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
   - [Outbound] Kafka consumer ready check utility function - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
-  - [Rig] Possibility to set logging level with env var `LOG_LEVEL` globally for RIG - [#50](https://github.com/Accenture/reactive-interaction-gateway/pull/50)
+  - [Rig] Possibility to set logging level with env var `LOG_LEVEL` - [#49](https://github.com/Accenture/reactive-interaction-gateway/pull/49)
 
 - Fixed
   - [Inbound] Make presence channel respect `JWT_USER_FIELD` setting (currently hardcoded to "username")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - [Deploy] Kubernetes deployment configuration file - [#29](https://github.com/Accenture/reactive-interaction-gateway/pull/29)
   - [Misc] Smoke tests setup and test cases for API Proxy and Kafka + Phoenix messaging - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
   - [Outbound] Kafka consumer ready check utility function - [#42](https://github.com/Accenture/reactive-interaction-gateway/pull/42)
+  - [Rig] Possibility to set logging level with env var `LOG_LEVEL` globally for RIG - [#49](https://github.com/Accenture/reactive-interaction-gateway/pull/49)
 
 - Fixed
   - [Inbound] Make presence channel respect `JWT_USER_FIELD` setting (currently hardcoded to "username")

--- a/apps/rig/lib/rig/application.ex
+++ b/apps/rig/lib/rig/application.ex
@@ -2,9 +2,14 @@ defmodule Rig.Application do
   @moduledoc false
 
   use Application
+  use Rig.Config, []
 
   def start(_type, _args) do
     alias Supervisor.Spec
+
+    # Override application logging with environment variable
+    conf = config()
+    Logger.configure [{:level, conf.log_level}]
 
     Rig.Discovery.start()
 

--- a/apps/rig/lib/rig/application.ex
+++ b/apps/rig/lib/rig/application.ex
@@ -2,14 +2,13 @@ defmodule Rig.Application do
   @moduledoc false
 
   use Application
-  use Rig.Config, []
+  use Rig.Config, [:log_level]
 
   def start(_type, _args) do
     alias Supervisor.Spec
 
     # Override application logging with environment variable
-    conf = config()
-    Logger.configure [{:level, conf.log_level}]
+    Logger.configure([{:level, config().log_level}])
 
     Rig.Discovery.start()
 

--- a/apps/rig_inbound_gateway/config/prod.exs
+++ b/apps/rig_inbound_gateway/config/prod.exs
@@ -15,9 +15,6 @@ config :rig, RigInboundGatewayWeb.Endpoint,
   env: :prod,
   check_origin: false
 
-# Do not print debug messages in production
-config :logger, level: :info
-
 # ## Using releases
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/apps/rig_inbound_gateway/config/test.exs
+++ b/apps/rig_inbound_gateway/config/test.exs
@@ -7,9 +7,6 @@ config :rig, RigInboundGatewayWeb.Endpoint,
   http: [port: System.get_env("INBOUND_PORT") || 4001],
   server: false
 
-# Print only warnings and errors during test
-config :logger, level: :warn
-
 config :rig, RigInboundGateway.RateLimit,
   enabled?: true,
   avg_rate_per_sec: 0,

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,9 @@ config :logger, :console,
   format: "\n$time [$level] $levelpad$message\n$metadata\n",
   metadata: metadata |> Enum.uniq()
 
+config :rig, Rig.Application,
+  log_level: {:system, :atom, "LOG_LEVEL", :debug}
+
 # --------------------------------------
 # User Roles
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,8 @@
 use Mix.Config
 
 # Do not print debug messages in production
-config :logger, level: :warn
+config :rig, Rig.Application,
+  log_level: {:system, :atom, "LOG_LEVEL", :warn}
 
 # --------------------------------------
 # Peerage

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,8 @@
 use Mix.Config
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :rig, Rig.Application,
+  log_level: {:system, :atom, "LOG_LEVEL", :warn}
 
 jwt_secret_key = "mysecret"
 

--- a/guides/operator-guide.md
+++ b/guides/operator-guide.md
@@ -14,5 +14,6 @@ Variable | Description | Default
 `JWT_USER_FIELD` | The JSON web token as sent by the front-ends should contain the user ID, in the same format used by the back-ends in the messages they send towards the user. `JWT_USER_FIELD` is the name of that user ID field in the JWT. For the corresponding field used in outbound messages, see `MESSAGE_USER_FIELD`. | "user"
 `MESSAGE_USER_FIELD` | (Outbound) messages are expected to be in JSON format. For routing the message to a specific user, RIG expects the user's ID to be present in such a JSON message. The corresponding JSON field is defined by `MESSAGE_USER_FIELD`. | "user"
 `KAFKA_ENABLED` | If enabled, RIG will consume messages from a Kafka broker using the configured broker and topic(s). | false
+`LOG_LEVEL` | Controls logging level for RIG, available values are: "debug", "info", "warn", "error". Production is using "warn" level. | :debug
 
 .


### PR DESCRIPTION
- added possibility to change logging level with env var
- it's a simple solution if we would like to support separate logger for umbrella app in future, we would probably need to add logger backend, for this this should suffice

**Test:**

- try to run test or app with and without `LOG_LEVEL` env var, should work as expected

Closes #49 