### PR TITLE
Set WebSocket timeout to infinity

### DIFF
--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway_web/presence/socket.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway_web/presence/socket.ex
@@ -10,7 +10,7 @@ defmodule RigInboundGatewayWeb.Presence.Socket do
   channel "role:*", RigInboundGatewayWeb.Presence.Channel
 
   ## Transports
-  transport :websocket, Phoenix.Transports.WebSocket
+  transport :websocket, Phoenix.Transports.WebSocket, timeout: :infinity
   transport :longpoll, Phoenix.Transports.LongPoll
   transport :sse, RigInboundGateway.Transports.ServerSentEvents
 


### PR DESCRIPTION
By default, Phoenix will close WebSockets when not receiving messages
for some time. In our use case, the client won't send anything, so
  closing it due to inactivity on the client side does not make sense.