### PR TITLE
[WIP] inbound: Simplify SSE API by removing params, using authz header instead 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - [Docs] Move documentation from `doc/` to `guides/` as the former is the default for ex_doc output
   - [Inbound] Revised request logging (currently Kafka and console as backends)
   - [Inbound] Disable WebSocket timeout - [#58](https://github.com/Accenture/reactive-interaction-gateway/pull/58)
+  - [Inbound] The Server-Sent Events endpoint no longer accepts any query parameters. Instead it expects the JWT to be set as the authorization bearer token in the HTTP header, where it extracts the user ID from. The connection is then subscribed to the users channel automatically. Previously, it was also possible to subscribe to other users' channels, but going forward, this is only possible using the (non-public) API. - [#65](https://github.com/Accenture/reactive-interaction-gateway/issues/65)
   - [Deploy] Dockerfile to use custom `vm.args` file & removed `mix release.init` step - [#29](https://github.com/Accenture/reactive-interaction-gateway/pull/29)
 
 - Added

--- a/README.md
+++ b/README.md
@@ -66,12 +66,10 @@ docker run \
 RIG is now ready to accept front-end connections. Let's simulate a browser app that uses [Server-Sent Events](https://en.wikipedia.org/wiki/Server-sent_events) to subscribe to RIG, using curl:
 
 ```bash
-curl "localhost:4000/socket/sse?users\[\]=alice&token=$token"
+curl -H "Authorization: Bearer $token" localhost:4000/socket/sse
 ```
 
-The username should match what's in the token, otherwise RIG won't allow you to connect.
-
-You should see some messages now, followed by incoming heartbeat events. Fire up another terminal window, where we can push a message through RIG:
+This hooks you up to alice' event stream, and you should see now "event: connection established", followed by "heartbeat" events. Fire up another terminal window to push a message through RIG:
 
 ```bash
 curl -H 'content-type: application/json' -d '{"user":"alice","text":"Hi, Alice!"}' localhost:4010/v1/messages
@@ -79,7 +77,7 @@ curl -H 'content-type: application/json' -d '{"user":"alice","text":"Hi, Alice!"
 
 After this you should see "Hi, Alice!" popping up in the other window! :tada:
 
-Note that for posting the message we've used another port---that's the _internal_ port running RIG's API. While the external port (4000) can be exposed to the internet, the internal one (4010) is meant to be used by your back-end services only.
+Note that for posting the message we've used a different port---that's the _internal_ port running RIG's API. While the external port (4000) can be exposed to the internet, the internal one (4010) is meant to be used by your back-end services only.
 
 ## Feature Summary
 

--- a/apps/rig_inbound_gateway/config/config.exs
+++ b/apps/rig_inbound_gateway/config/config.exs
@@ -97,8 +97,7 @@ jwt_payload_field_map = %{
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 config :rig, RigInboundGateway.Transports.ServerSentEvents,
-  user_channel_name_mf: {RigInboundGatewayWeb.Presence.Channel, :user_channel_name},
-  role_channel_name_mf: {RigInboundGatewayWeb.Presence.Channel, :role_channel_name}
+  user_channel_name_mf: {RigInboundGatewayWeb.Presence.Channel, :user_channel_name}
 
 config :rig, RigInboundGatewayWeb.Presence.Channel,
   # See "JWT payload fields"

--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway/transports/server_sent_events.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway/transports/server_sent_events.ex
@@ -16,17 +16,27 @@ defmodule RigInboundGateway.Transports.ServerSentEvents do
 
   alias RigInboundGateway.Transports.ServerSentEvents.Encoder
 
+  @token_query_param "auth_token"
+  @usage_text """
+  Please make sure that the HTTP Authorization header contains the JWT as the bearer token.
+
+  Usage:
+
+    GET /socket/sse
+    Authorization: Bearer eyJhbGc...
+  """
+
   defmodule ConnectionClosed do
     defexception message: "connection closed"
   end
 
   defp validate_config!(nil), do: validate_config!([])
+
   defp validate_config!(config) do
     {user_target_mod, user_target_fun} = Keyword.fetch!(config, :user_channel_name_mf)
-    {role_target_mod, role_target_fun} = Keyword.fetch!(config, :role_channel_name_mf)
+
     %{
-      user_channel_name: fn user -> apply(user_target_mod, user_target_fun, [user]) end,
-      role_channel_name: fn role -> apply(role_target_mod, role_target_fun, [role]) end,
+      user_channel_name: fn user -> apply(user_target_mod, user_target_fun, [user]) end
     }
   end
 
@@ -38,7 +48,7 @@ defmodule RigInboundGateway.Transports.ServerSentEvents do
     [
       heartbeat_timeout_ms: 10_000,
       serializer: RigInboundGateway.Transports.ServerSentEvents.Serializer,
-      cowboy: Plug.Adapters.Cowboy.Handler,
+      cowboy: Plug.Adapters.Cowboy.Handler
     ]
   end
 
@@ -49,6 +59,7 @@ defmodule RigInboundGateway.Transports.ServerSentEvents do
   import Plug.Conn
 
   alias Phoenix.Socket.Transport
+  alias RigAuth.Jwt.Utils, as: Jwt
 
   @doc false
   def init(opts), do: opts
@@ -60,24 +71,41 @@ defmodule RigInboundGateway.Transports.ServerSentEvents do
   """
   def call(conn, {endpoint, handler, transport}) do
     {_, opts} = handler.__transport__(transport)
+
     conn
-    |> fetch_query_params
     |> put_resp_header("access-control-allow-origin", "*")
-    |> Plug.Conn.fetch_query_params
+    |> Plug.Conn.fetch_query_params()
     |> Transport.transport_log(opts[:transport_log])
     |> Transport.force_ssl(handler, endpoint, opts)
     |> Transport.check_origin(handler, endpoint, opts, &status_json(&1, %{}))
     |> dispatch(endpoint, handler, transport, opts)
   end
 
-  defp dispatch(%{halted: true} = conn, _, _, _, _) do
-    conn
+  defp dispatch(conn, endpoint, handler, transport, opts) do
+    case conn do
+      %{halted: true} ->
+        # The connection hasn't survived the previous checks..
+        conn
+
+      %{method: "OPTIONS"} ->
+        # Handle pre-flight CORS requests:
+        handle_options_request(conn)
+
+      %{method: "GET"} ->
+        # Have the connection subscribed to the user topic:
+        attach_to_user_socket(conn, endpoint, handler, transport, opts)
+
+      _ ->
+        # Fail all other requests:
+        send_resp(conn, :bad_request, error_response_text("Bad request."))
+    end
   end
 
   # Responds to pre-flight CORS requests with Allow-Origin-* headers.
   # We allow cross-origin requests as we always validate the Origin header.
-  defp dispatch(%{method: "OPTIONS"} = conn, _, _, _, _) do
+  defp handle_options_request(conn) do
     headers = get_req_header(conn, "access-control-request-headers") |> Enum.join(", ")
+
     conn
     |> put_resp_header("access-control-allow-headers", headers)
     |> put_resp_header("access-control-allow-methods", "get, post, options")
@@ -85,69 +113,115 @@ defmodule RigInboundGateway.Transports.ServerSentEvents do
     |> send_resp(:ok, "")
   end
 
-  # Sets up the actual SSE transport by connecting to the socket and channel,
-  # forwarding incoming messages to the client.
-  #
-  # Expected parameters:
-  #   token .. (required) the JWT, which will be validated by the socket.
-  #   users .. if given, messages that target the given users are forwarded to the client.
-  #   roles .. if given, messages that target the given roles are forwarded to the client.
-  #
-  defp dispatch(%{method: "GET", params: %{"token" => _token} = params} = conn,
-                endpoint, handler, transport_name, opts) do
+  defp attach_to_user_socket(
+         conn,
+         endpoint,
+         handler,
+         transport_name,
+         opts
+       ) do
     conf = config()
-    user_channels = Map.get(params, "users", []) |> Enum.map(conf.user_channel_name)
-    role_channels = Map.get(params, "roles", []) |> Enum.map(conf.role_channel_name)
-    channels = Enum.uniq(user_channels ++ role_channels)
-    case channels do
-      [] ->
-        conn
-        |> send_resp(:not_found, "no channels selected\n")
-      _ ->
-        conn
-        |> connect_subscribe_listen_forward(endpoint, handler, transport_name, channels, opts)
+    serializer = opts[:serializer]
+
+    token = get_token(conn)
+    conn = Map.put(conn, :params, Map.put(conn.params, "token", token))
+
+    with {:ok, user_id} <- user_id_from_token(token),
+         user_channel_name <- conf.user_channel_name.(user_id),
+         {:ok, socket} <- open_socket(endpoint, handler, transport_name, serializer, conn.params),
+         {:ok, _reply} <- subscribe_to_channel(socket, user_channel_name) do
+      conn
+      |> set_up_chunked_transfer()
+      |> send_chunk(:hello)
+      |> attach_to_channel(opts)
+      # TODO publish leave messages to topic
+      |> send_chunk(:bye)
+    else
+      {:error, :socket_connection_denied} ->
+        send_resp(conn, :unauthorized, :unauthorized |> Encoder.format())
+
+      {:error, :no_token} ->
+        send_resp(conn, :bad_request, "No bearer token found.")
+
+      {:error, :invalid_token} ->
+        send_resp(conn, :bad_request, "Bearer token is not valid.")
+
+      err ->
+        Logger.warn(fn ->
+          "Channel subscription failed: #{inspect(err)}"
+        end)
+
+        send_resp(conn, :internal_server_error, "Internal server error.")
     end
   rescue
     ex in ConnectionClosed ->
-      Logger.warn(inspect ex)
+      Logger.warn(inspect(ex))
       # we should return _something_, so as to prevent a Plug.Conn.NotSentError:
-      conn |> send_resp(:service_unavailable, :service_unavailable |> Encoder.format)
+      conn |> send_resp(:service_unavailable, :service_unavailable |> Encoder.format())
   end
 
-  # All other requests should fail.
-  defp dispatch(conn, _, _, _, _) do
-    conn
-    |> send_resp(:bad_request,
-                 """
-                 Bad request. Make sure you supply the right parameters, and that you're authorized to access the user's channel.
-
-                 Example: ?users[]=some.user&users[]=other.user&roles[]=support&token=my-jwt
-                 """)
+  @type user_id_error :: {:error, :no_token | :invalid_token | String.t()}
+  @spec user_id_from_token(String.t()) :: {:ok, String.t()} | user_id_error
+  defp user_id_from_token(token) do
+    with true <- not is_nil(token) || {:error, :no_token},
+         true <- Jwt.valid?(token) || {:error, :invalid_token},
+         {:ok, %{"user" => user_id}} <- Jwt.decode(token) do
+      {:ok, user_id}
+    end
   end
 
-  defp connect_subscribe_listen_forward(conn, endpoint, handler, transport_name,
-                                        channels, opts) when length(channels) > 0 do
-    case Transport.connect(endpoint, handler,
-                           transport_name, _transport = __MODULE__,
-                           opts[:serializer], conn.params) do
-      {:ok, socket} ->
-        # We're connected to the socket now, but we still need to join the channel.
-        conn = conn |> set_up_chunked_transfer
-        ok? =
-          socket
-          |> subscribe_to_channels(channels)
-          |> Enum.map(fn(reply) -> handle_dispatch_reply(reply, conn, opts[:serializer]) end)
-          |> Enum.all?(&(&1 == :ok))
-        if ok? do
-          conn |> receive_and_forward_loop(opts)
-        else
-          conn
-        end
-        |> send_chunk(:bye)
-      :error ->
-        Logger.debug(fn -> "failed to connect with socket transport=#{inspect transport_name}/#{inspect __MODULE__} (opts=#{inspect opts}) handler=#{inspect handler} conn=#{inspect conn, pretty: true, limit: 30_000}" end)
-        conn
-        |> send_resp(:unauthorized, :unauthorized |> Encoder.format)
+  @spec get_token(conn :: %Plug.Conn{}) :: String.t() | nil
+  defp get_token(conn) do
+    # Putting the token into the query overrides what's in the header:
+    case token_from_query(conn) do
+      nil ->
+        # No token in the query, return what's in the header (might be nil):
+        token_from_header(conn)
+
+      query_token ->
+        # There is a token! If there is an authZ header too, they need to match:
+        header_token = token_from_header(conn)
+        ensure_no_or_matching_header_token(query_token, header_token)
+    end
+  end
+
+  defp ensure_no_or_matching_header_token(query_token, nil), do: query_token
+
+  defp ensure_no_or_matching_header_token(query_token, header_token) do
+    # If they don't match, we ignore the tokens altogether:
+    if query_token == header_token, do: query_token, else: nil
+  end
+
+  @spec token_from_header(conn :: %Plug.Conn{}) :: String.t() | nil
+  defp token_from_header(conn) do
+    case get_req_header(conn, "authorization") do
+      [value | _] -> token_from_bearer(value)
+      _ -> nil
+    end
+  end
+
+  # This is the (OAuth) standard:
+  defp token_from_bearer("Bearer " <> token), do: token
+  # This is not, but we accept it anyway:
+  defp token_from_bearer("bearer " <> token), do: token
+  defp token_from_bearer(_), do: nil
+
+  @spec token_from_query(conn :: %Plug.Conn{}) :: String.t() | nil
+  defp token_from_query(conn) do
+    Map.get(conn.params, @token_query_param, nil)
+  end
+
+  defp open_socket(endpoint, handler, transport_name, serializer, params) do
+    case Transport.connect(
+           endpoint,
+           handler,
+           transport_name,
+           _transport = __MODULE__,
+           serializer,
+           params
+         ) do
+      {:ok, socket} -> {:ok, socket}
+      _ -> {:error, :socket_connection_denied}
     end
   end
 
@@ -156,71 +230,92 @@ defmodule RigInboundGateway.Transports.ServerSentEvents do
     |> merge_resp_headers([
       {"content-type", "text/event-stream"},
       {"cache-control", "no-cache"},
-      {"connection", "keep-alive"},
+      {"connection", "keep-alive"}
     ])
     |> send_chunked(_status = 200)
   end
 
-  defp subscribe_to_channels(socket, channels) do
-    Enum.map(channels, fn
-      (channel) ->
-        # Special message for joining the channel:
-        join_msg = %Phoenix.Socket.Message{topic: channel, event: "phx_join", payload: %{}}
-        # If successful, we get subscribed to the channel. Note that if we
-        # would just subscribe to the respective PubSub topic directly, we'd
-        # skip the socket's auth check as well as the channel implementation.
-        Transport.dispatch(join_msg, _channels = %{}, socket)
-      end)
+  defp subscribe_to_channel(socket, channel) do
+    # Special message for joining the channel:
+    join_msg = %Phoenix.Socket.Message{topic: channel, event: "phx_join", payload: %{}}
+    # If successful, we get subscribed to the channel. Note that if we
+    # would just subscribe to the respective PubSub topic directly, we'd
+    # skip the socket's auth check as well as the channel implementation.
+    case Transport.dispatch(join_msg, _channels = %{}, socket) do
+      {:joined, _channel_pid, reply_msg} ->
+        {:ok, reply_msg}
+
+      {:error, reason, error_reply_msg} ->
+        {:error, :channel_subscription_failed, reason, error_reply_msg}
+    end
   end
 
-  defp handle_dispatch_reply({:joined, _channel_pid, reply_msg}, conn, serializer) do
-    Logger.debug(fn -> ":joined msg=#{inspect reply_msg}" end)
-    conn
-    |> send_chunk(reply_msg |> serializer.encode! |> Encoder.format)
-    :ok
-  end
-  defp handle_dispatch_reply({:error, reason, error_reply_msg}, conn, serializer) do
-    Logger.debug(fn -> ":error reason=#{inspect reason} msg=#{inspect error_reply_msg}" end)
-    conn
-    |> send_resp(:internal_server_error, error_reply_msg |> serializer.encode! |> Encoder.format)
-    :error
+  defp attach_to_channel(conn, opts, next_heartbeat_timeout \\ nil)
+
+  defp attach_to_channel(conn, opts, nil) do
+    attach_to_channel(conn, opts, get_next_heartbeat_timeout(opts))
   end
 
-  defp receive_and_forward_loop(conn, opts, next_heartbeat_timeout \\ nil)
-  defp receive_and_forward_loop(conn, opts, nil) do
-    receive_and_forward_loop(conn, opts, get_next_heartbeat_timeout(opts))
-  end
-  defp receive_and_forward_loop(conn, opts, next_heartbeat_timeout) do
+  defp attach_to_channel(conn, opts, next_heartbeat_timeout) do
     heartbeat_remaining_ms =
       next_heartbeat_timeout
-      |> Timex.diff(Timex.now, :milliseconds)
+      |> Timex.diff(Timex.now(), :milliseconds)
       |> max(0)
+
     receive do
+      {:cowboy_req, _} ->
+        # Cowboy events are ignored.
+        attach_to_channel(conn, opts, next_heartbeat_timeout)
+
+      {:plug_conn, _} ->
+        # Plug events are ignored.
+        attach_to_channel(conn, opts, next_heartbeat_timeout)
+
+      %Phoenix.Socket.Message{event: "presence_state"} ->
+        # Phoenix events are ignored.
+        attach_to_channel(conn, opts, next_heartbeat_timeout)
+
+      %Phoenix.Socket.Message{event: "presence_diff"} ->
+        # Phoenix events are ignored.
+        attach_to_channel(conn, opts, next_heartbeat_timeout)
+
+      %Phoenix.Socket.Message{event: "phx_reply"} ->
+        # Phoenix events are ignored.
+        attach_to_channel(conn, opts, next_heartbeat_timeout)
+
       %Phoenix.Socket.Message{} = msg ->
-        Logger.debug(fn -> "from channel: message=#{inspect msg}" end)
+        Logger.debug(fn -> "from channel: message=#{inspect(msg)}" end)
+
         conn
-        |> send_chunk(msg |> Encoder.format)
-        |> receive_and_forward_loop(opts, next_heartbeat_timeout)
+        |> send_chunk(msg |> Encoder.format())
+        |> attach_to_channel(opts, next_heartbeat_timeout)
+
+      unexpected_msg ->
+        Logger.warn(fn -> "Unexpectedly received: #{inspect(unexpected_msg)}" end)
+        attach_to_channel(conn, opts, next_heartbeat_timeout)
     after
       heartbeat_remaining_ms ->
         # If the connection is down, the (second) heartbeat will trigger ConnectionClosed
         conn
         |> send_chunk(:heartbeat)
-        |> receive_and_forward_loop(opts, get_next_heartbeat_timeout(opts))
+        |> attach_to_channel(opts, get_next_heartbeat_timeout(opts))
     end
   end
 
   defp get_next_heartbeat_timeout(opts) do
-    Timex.now |> Timex.shift(milliseconds: opts[:heartbeat_timeout_ms])
+    Timex.now() |> Timex.shift(milliseconds: opts[:heartbeat_timeout_ms])
   end
 
   defp send_chunk(conn, the_chunk) when is_binary(the_chunk) do
     case chunk(conn, the_chunk) do
-      {:ok, conn} -> conn
+      {:ok, conn} ->
+        conn
+
       {:error, :closed} ->
         raise ConnectionClosed
     end
   end
+
   defp send_chunk(conn, thing) do
     send_chunk(conn, Encoder.format(thing))
   end
@@ -228,8 +323,13 @@ defmodule RigInboundGateway.Transports.ServerSentEvents do
   defp status_json(conn, data) do
     status = Plug.Conn.Status.code(conn.status || 200)
     data = Map.put(data, :status, status)
+
     conn
     |> put_status(200)
     |> Phoenix.Controller.json(data)
+  end
+
+  defp error_response_text(reason) do
+    "\n#{reason}\n\n#{@usage_text}\n\n"
   end
 end

--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway/transports/server_sent_events/encoder.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway/transports/server_sent_events/encoder.ex
@@ -11,6 +11,7 @@ defmodule RigInboundGateway.Transports.ServerSentEvents.Encoder do
     <> format_data(msg)
     <> "\n"
   end
+  def format(:hello), do: "event: connection established\n\n"
   def format(:heartbeat), do: "event: heartbeat\n\n"
   def format(:bye), do: "event: closing connection\n\n"
   # For handling HTTP status codes:

--- a/examples/channels-example/frontend/src/utils/sse.js
+++ b/examples/channels-example/frontend/src/utils/sse.js
@@ -17,12 +17,11 @@ export class Sse {
         const token = getJwtToken(username, levelsArray);
 
         // Creates SSE connection and subscribes to user's Phoenix channel
-        this.socket = new EventSource(`/socket/sse?users[]=${subscriberTopic}&token=${token}`);
+        this.socket = new EventSource(`/socket/sse?auth_token=${token}`);
 
         // Wait for RIG's Phoenix channel reply and executes callback
-        this.socket.addEventListener('phx_reply', ({ data }) => {
-            const { status, response } = JSON.parse(data).payload;
-            cb({ status, response });
+        this.socket.addEventListener('connection established', () => {
+            cb({ status: "ok", response: "connection established" });
         });
 
         return this;


### PR DESCRIPTION
The Server-Sent Events endpoint no longer accepts any query parameters. Instead it expects the JWT to be set as the authorization bearer token in the HTTP header, where it extracts the user ID from. The connection is then subscribed to the users channel automatically. Previously, it was also possible to subscribe to other users' channels, but going forward, this is only possible using the (non-public) API (which will be worked on in a future PR).

Relates to #65 
Fixes #68, #64 