### PR TITLE
Removed user id parameter from terminate session api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.0.0-dev
 
 - Changed
+  - [Api] Endpoint for terminating a session no longer contains user id in path
   - [Misc] Convert to umbrella project layout
   - [Docs] Move documentation from `doc/` to `guides/` as the former is the default for ex_doc output
   - [Inbound] Revised request logging (currently Kafka and console as backends)

--- a/apps/rig_api/lib/rig_api/router.ex
+++ b/apps/rig_api/lib/rig_api/router.ex
@@ -14,7 +14,11 @@ defmodule RigApi.Router do
     pipe_through :api
     get "/", ChannelsController, :list_channels
     get "/:user/sessions", ChannelsController, :list_channel_sessions
-    delete "/:user/sessions/:jti", ChannelsController, :disconnect_channel_session
+  end
+
+  scope "/v1/sessions", RigApi do
+    pipe_through :api
+    delete "/:jti", ChannelsController, :disconnect_channel_session
   end
 
   scope "/v1/apis", RigApi do

--- a/apps/rig_api/test/rig_api/controllers/channels_controller_test.exs
+++ b/apps/rig_api/test/rig_api/controllers/channels_controller_test.exs
@@ -38,11 +38,11 @@ defmodule RigApi.ChannelsControllerTest do
     leave sock
   end
 
-  test "DELETE /v1/users/testuser/sessions/abc123 should broadcast disconnect event to user with jti abc123", %{sock: sock} do
+  test "DELETE /v1/sessions/abc123 should broadcast disconnect event to user with jti abc123", %{sock: sock} do
     @endpoint_channels.subscribe("abc123")
     conn =
       build_conn()
-      |> delete("/v1/users/testuser/sessions/abc123")
+      |> delete("/v1/sessions/abc123")
 
     assert_broadcast("disconnect", %{})
     assert response(conn, 204) =~ "{}"


### PR DESCRIPTION
Addressing #55.

As discussed in the issue linked above I've changed the terminate session endpoint to not contain user id in the path.

This is a pretty simple change. Hopefully I didn't forget anything.

The old endpoint has been removed as I am not sure how we are handling endpoint deprecation.
This is a breaking change after all, supposed land in v2.0.