### PR TITLE
Fix helm chart

### DIFF
--- a/deployment/helm/reactive-interaction-gateway/templates/deployment.yaml
+++ b/deployment/helm/reactive-interaction-gateway/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: API_PORT
+              value: {{ .Values.apiPort | quote }}
+            - name: INBOUND_PORT
+              value: {{ .Values.inboundPort | quote }}
           ports:
             - name: api-port
               containerPort: {{ .Values.apiPort }}

--- a/deployment/helm/reactive-interaction-gateway/values.yaml
+++ b/deployment/helm/reactive-interaction-gateway/values.yaml
@@ -24,6 +24,6 @@ deployment:
   env:
     PROXY_CONFIG_FILE: proxy/proxy.test.json
     DISCOVERY_TYPE: dns
-    DNS_NAME: reactive-interaction-gateway-service-headless.default.svc.cluster.local
+    DNS_NAME: reactive-interaction-gateway-headless.default.svc.cluster.local
     NODE_COOKIE: magiccookie
     JWT_SECRET_KEY: asdf


### PR DESCRIPTION
- addressed second issue in #69 - updated value for DNS in helm chart
- first issue with port is understandable, but I would keep this chart example simple to be 1:1 with kubernetes config (to be able to compare it)

closes #69 