### PR TITLE
Kuberenetes deployment documentation update

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,13 +4,15 @@ Reactive Interaction Gateway (RIG) uses [Peerage library](https://github.com/mrl
 
 **Note:** If you don't care about distributed mode and don't want to do discovery, follow just `General configuration` section and ignore rest of the text.
 
-## General configuration
+## Configuration
+
+### General configuration
 
 1. Node host - Every node in cluster needs to be discoverable by other nodes. For that Elixir/Erlang uses so called `long name` or `short name`. We are using `long name` which is formed in the following way `app_name@node_host`. `app_name` is in our case set to `rig`, but `node_host` is taken from environment variable `NODE_HOST`. This can be either IP or container alias or whatever that is routable in network by other nodes.
 
 1. Node cookie - Nodes in Erlang cluster use cookies as a form of authorization/authentication between them. Only nodes with the same cookie can communicate together. It should be ideally some generated hash, set it to `NODE_COOKIE` environment variable.
 
-## DNS discovery
+### DNS discovery
 
 RIG currently supports distributed deployment via DNS discovery. To make it work, you need to set two things:
 
@@ -19,3 +21,9 @@ RIG currently supports distributed deployment via DNS discovery. To make it work
 1. DNS name (address) - Address where peerage will do discovery for Node host addresses. Value is taken from environment variable `DNS_NAME`.
 
 DNS discovery is executed every 5 seconds.
+
+### Additional configuration
+When running in distributed mode, additional variables may be passed to the deployment in order to run the proper configuration.
+Changes to these variables are required in most production circumstances.
+
+For more information on configuration variables, please view the [Operators Guide to the RIG](https://accenture.github.io/reactive-interaction-gateway/docs/rig-ops-guide.html)

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -32,6 +32,12 @@ Address upon which RIG will do DNS discovery. This has to point to Kubernetes he
   value: "reactive-interaction-gateway-service-headless.default.svc.cluster.local"
 ```
 
+### Additional Configuration
+When running in distributed mode, additional variables may be passed to the deployment in order to run the proper configuration. Updates to the helm chart can be made in ```helm/reactive-interaction-gateway/values.yaml```
+Changes to these variables are required in most production circumstances.
+
+For more information on configuration variables, please view the [Operators Guide to the RIG](https://accenture.github.io/reactive-interaction-gateway/docs/rig-ops-guide.html)
+
 ## Running locally with Minikube
 
 If you want to use local image (either original RIG or your own based on original RIG):
@@ -48,7 +54,7 @@ If you want to use local image (either original RIG or your own based on origina
 1. `helm install deployment/helm/reactive-interaction-gateway` (assuming you are in root directory)
 1. `kubectl get pod,svc` should list a running RIG pod and two services
 
-**Note:** Services should communicate with `reactive-interaction-gateway-service` which is reachable within Kubernetes cluster (but not outside of server) on port 4000 (by default). This service will load balance requests amongst replicas.
+**Note:** Services should communicate with `reactive-interaction-gateway-service` which is reachable within Kubernetes cluster (but not outside of server) on port 4000 (by default). This service will load balance requests amongst replicas. Changes to the service can by done by modify the configuration in values.yaml to allow external communcation with ``` type:LoadBalancer```
 
 ## Scaling
 1. Get the name of the deployment ```kubectl get deployments```

--- a/deployment/k8s/README.md
+++ b/deployment/k8s/README.md
@@ -32,6 +32,12 @@ Address upon which RIG will do DNS discovery. This has to point to Kubernetes he
   value: "reactive-interaction-gateway-service-headless.default.svc.cluster.local"
 ```
 
+### Additional Configuration
+When running in distributed mode, additional variables may be passed to the deployment in order to run the proper configuration. Updates to the helm chart can be made in ```helm/reactive-interaction-gateway/values.yaml```
+Changes to these variables are required in most production circumstances.
+
+For more information on configuration variables, please view the [Operators Guide to the RIG](https://accenture.github.io/reactive-interaction-gateway/docs/rig-ops-guide.html)
+
 ## Running locally with Minikube
 
 If you want to use local image (either original RIG or your own based on original RIG):


### PR DESCRIPTION
The purpose of this PR is to make mild updates to the documentation surrounding  Kuberenetes deployment. No application code changes have been made

* Updated the general deployment documentation to include direct linkto the operators guide, and associated mild formatting update.
* Updated the helm deployment documentation to include link to the operators guide, as well as adding a mentioning the modification to values.yaml to allow external exposure.
* Updated the K8S deployment documentation to include link to the operators guide