### PR TITLE
Revert prep to split up inbound server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Proxy and Event Hub no longer use the same port and both support transport encryption now. Consequently, the `INBOUND_PORT` settings has been dropped in favor of `API_HTTP_PORT`, `API_HTTPS_PORT`, `PROXY_HTTP_PORT`, `PROXY_HTTPS_PORT`, `EVENT_HUB_HTTP_PORT`, `EVENT_HUB_HTTPS_PORT`, `HTTPS_CERTFILE`, `HTTPS_KEYFILE`, and `HTTPS_KEYFILE_PASS`. Consult the [Operator's Guide](docs/rig-ops-guide.md) for a detailed description of those settings.
 - The SSE and WebSocket endpoints' "token" parameter is renamed to "jwt" (to not confuse it with the connection token).
 - [Proxy] When forwarding requests, RIG related meta data (e.g. correlation ID) in CloudEvents is now put into an object under the top-level key "rig". Note that in terms of the current [CloudEvents 0.2](https://github.com/cloudevents/spec/blob/v0.2/spec.md) specification this makes "rig" an [extension](https://github.com/cloudevents/spec/blob/v0.2/primer.md#cloudevent-attribute-extensions). Also, all RIG related keys have been renamed from snake_case to camelCase.
 - [Proxy] Previously API definitions for proxy were turning on security check for endpoints by `not_secured: false` which is a bit confusing -- changed to more readable form `secured: true`.

--- a/apps/rig_inbound_gateway/config/config.exs
+++ b/apps/rig_inbound_gateway/config/config.exs
@@ -38,14 +38,12 @@ config :rig_inbound_gateway, RigInboundGatewayWeb.Endpoint,
     host: {:system, "HOST", "localhost"}
   ],
   http: [
-    # TODO: split this endpoint into one for the proxy and one for the event hub,
-    # TODO: then use the respective port settings.
-    port: {:system, :integer, "PROXY_HTTP_PORT", 4000},
+    port: {:system, :integer, "INBOUND_PORT", 4000},
     dispatch: cowboy_dispatch,
     transport_options: ranch_transport_options
   ],
   https: [
-    port: {:system, :integer, "PROXY_HTTPS_PORT", 4001},
+    port: {:system, :integer, "INBOUND_HTTPS_PORT", 4001},
     otp_app: :rig,
     cipher_suite: :strong,
     certfile: "cert/selfsigned.pem",

--- a/docs/rig-ops-guide.md
+++ b/docs/rig-ops-guide.md
@@ -14,10 +14,8 @@ Variable&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 -------------- | ----------- | -------
 `API_HTTP_PORT` | Port at which RIG exposes internal APIs such as API Proxy management or user connections management. | nil
 `API_HTTPS_PORT` | Same as `API_HTTP_PORT`, but encrypted. See `HTTPS_CERTFILE`, `HTTPS_KEYFILE`, `HTTPS_KEYFILE_PASS`. | nil
-`PROXY_HTTP_PORT` | RIG's ingress port that is used to proxy/forward incoming client requests. | 4000
-`PROXY_HTTPS_PORT` | Same as `PROXY_HTTP_PORT`, but encrypted. See `HTTPS_CERTFILE`, `HTTPS_KEYFILE`, `HTTPS_KEYFILE_PASS`. | 4001
-`EVENT_HUB_HTTP_PORT` | Port used by clients to connect to RIG itself, e.g., for consuming events via SSE or WebSockets. | nil
-`EVENT_HUB_HTTPS_PORT` | Same as `EVENT_HUB_HTTP_PORT`, but encrypted. See `HTTPS_CERTFILE`, `HTTPS_KEYFILE`, `HTTPS_KEYFILE_PASS`. | nil
+`INBOUND_PORT` | Port at which RIG exposes proxy and websocket/sse communication. | 4000
+`INBOUND_HTTPS_PORT` | Same as `INBOUND_PORT`, but encrypted. See `HTTPS_CERTFILE`, `HTTPS_KEYFILE`, `HTTPS_KEYFILE_PASS`. | 4000
 `HTTPS_CERTFILE` | Path to the (signed) client certificate (PEM format). Similar to `PROXY_CONFIG_FILE` the path is relative to the OTP app's `priv` directory. | nil
 `HTTPS_KEYFILE` | Path to the private key of the client certificate (PEM format). Also supports encrypted private keys; see `HTTPS_KEYFILE_PASS` and consult the Erlang documentation for supported ciphers (e.g. [supported password ciphers in OTP 21.2](https://github.com/erlang/otp/blob/OTP-21.2/lib/public_key/src/pubkey_pbe.erl#L55); unfortunately, with OTP 21.1 using an unsupported cipher fails silently). Similar to `PROXY_CONFIG_FILE` the path is relative to the OTP app's `priv` directory. | nil
 `HTTPS_KEYFILE_PASS` | Passphrase in case the private key is password-protected. | ""


### PR DESCRIPTION
The change is postponed (currently scheduled for 3.0).