### PR TITLE
Add publish_gh_pages Mix task to publish hexdocs to gh-pages branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ erl_crash.dump
 /website/build/
 
 # mix docs
-/website/static/reference
+/website/static/source_docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ stages:
   - test
   - name: website
     if: branch = master AND type != pull_request
+  - name: sourcedocs
+    if: branch = master AND type != pull_request
 
 jobs:
   include:
@@ -25,3 +27,9 @@ jobs:
         - git config --global user.email "${GH_EMAIL}"
         - echo "machine github.com login ${GH_NAME} password ${GH_TOKEN}" > ~/.netrc
         - cd website && yarn install && GIT_USER="${GH_NAME}" yarn run publish-gh-pages
+    - stage: sourcedocs
+      language: elixir
+      elixir: "1.7"
+      otp_release: "21.0"
+      script:
+        - mix publish_gh_pages

--- a/apps/rig/lib/mix/tasks/publish_gh_pages.ex
+++ b/apps/rig/lib/mix/tasks/publish_gh_pages.ex
@@ -1,0 +1,58 @@
+defmodule Mix.Tasks.PublishGhPages do
+  @moduledoc """
+  Publishes the API reference documentation (mix docs) to the gh-pages branch.
+
+  Fails if the branch doesn't exist.
+  """
+
+  use Mix.Task
+  require Logger
+
+  @target_branch "gh-pages"
+  @target_dir "source_docs"
+
+  @shortdoc "Publishes the output of mix docs to the gh-pages branch."
+  @impl true
+  def run(_) do
+    {:ok, git_user} =
+      with git_user when byte_size(git_user) > 0 <- System.get_env("GIT_USER"),
+           do: {:ok, git_user}
+
+    source_url =
+      Rig.Umbrella.Mixfile.project()[:source_url]
+      |> URI.parse()
+      |> Map.put(:userinfo, git_user)
+      |> URI.to_string()
+
+    docs_out_dir = System.tmp_dir!() |> Path.join("rig_source_docs")
+    File.rm_rf!(docs_out_dir)
+    File.mkdir!(docs_out_dir)
+    Mix.Task.run("docs", ["--output", docs_out_dir])
+
+    orig_ref =
+      case git(["rev-parse", "--abbrev-ref", "HEAD"]) do
+        "HEAD" ->
+          # This is a detached checkout -> we use the commit sha:
+          git(["rev-parse", "HEAD"])
+
+        branch when byte_size(branch) > 0 ->
+          branch
+      end
+
+    git(["checkout", "origin/#{@target_branch}"])
+    File.rm_rf!(@target_dir)
+    File.cp_r!(docs_out_dir, @target_dir)
+    git(["add", @target_dir])
+    git(["commit", "-m", "Deploy source documentation"])
+    git(["push", "--verbose", source_url, "HEAD:#{@target_branch}"])
+
+    # cleanup
+    File.rm_rf(docs_out_dir)
+    git(["checkout", orig_ref])
+  end
+
+  defp git(args) do
+    {stdout, 0} = System.cmd("git", args)
+    stdout |> String.trim()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -74,8 +74,11 @@ defmodule Rig.Umbrella.Mixfile do
           do: :"Elixir.#{Macro.camelize(snake_cased_string)}"
 
     [
+      # Website and documentation is built off master,
+      # so that's where we should link to:
+      source_ref: "master",
       main: "api-reference",
-      output: "website/static/reference",
+      output: "website/static/source_docs",
       extras: [
         "CHANGELOG.md": [title: "Changelog"]
       ],

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -43,8 +43,8 @@
       }
     },
     "links": {
-      "Docs": "Docs",
-      "API Reference": "API Reference"
+      "User Documentation": "User Documentation",
+      "Source Documentation": "Source Documentation"
     },
     "categories": {
       "Getting Started": "Getting Started",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -21,11 +21,11 @@ const siteConfig = {
   repoUrl: `https://github.com/accenture/reactive-interaction-gateway`,
   headerLinks: [{
       doc: 'intro',
-      label: 'Docs'
+      label: 'User Documentation'
     },
     {
-      href: 'reference/',
-      label: 'API Reference'
+      href: 'source_docs/',
+      label: 'Source Documentation'
     },
     // { page: 'help', label: 'Help' },
     // { blog: true, label: 'Blog' },


### PR DESCRIPTION
Tested manually. Note that the `publish-gh-pages` Docusaurus uses removes _all_ files in `gh-pages` before copying the website files, so `mix publish_gh_pages` must run afterwards.

Closes #142 