### PR TITLE
Remove SSE 60s timeout (cowboy 2.0's idle_timeout & inactivity_timeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- A library upgrade caused idle SSE connections to time out after 60 seconds. This timeout is now disabled.
 
 <!-- ### Security -->
 

--- a/apps/rig_inbound_gateway/config/config.exs
+++ b/apps/rig_inbound_gateway/config/config.exs
@@ -24,6 +24,13 @@ ranch_transport_options = [
   max_connections: :infinity
 ]
 
+cowboy_options = [
+  idle_timeout: :infinity,
+  inactivity_timeout: :infinity,
+  # Experimental feature that allows using WebSocket over HTTP/2:
+  enable_connect_protocol: true
+]
+
 cowboy_dispatch = [
   {:_,
    [
@@ -40,6 +47,7 @@ config :rig_inbound_gateway, RigInboundGatewayWeb.Endpoint,
   http: [
     port: {:system, :integer, "INBOUND_PORT", 4000},
     dispatch: cowboy_dispatch,
+    protocol_options: cowboy_options,
     transport_options: ranch_transport_options
   ],
   https: [
@@ -50,6 +58,7 @@ config :rig_inbound_gateway, RigInboundGatewayWeb.Endpoint,
     keyfile: "cert/selfsigned_key.pem",
     password: {:system, "HTTPS_KEYFILE_PASS", ""},
     dispatch: cowboy_dispatch,
+    protocol_options: cowboy_options,
     transport_options: ranch_transport_options
   ],
   render_errors: [view: RigInboundGatewayWeb.ErrorView, accepts: ~w(html json xml)],


### PR DESCRIPTION
Fixes that the SSE connection times out after 60 seconds, despite the heartbeats.

Tested:

- `http --stream :4000/_rig/v1/connection/sse`
- `curl --http2 http://localhost:4000/_rig/v1/connection/sse`
- `wscat -c "localhost:4000/_rig/v1/connection/ws"`
- `examples/sse-demo.html`