### PR TITLE
Fixed proxy parsing when atom was expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- [Proxy] Parsing of JSON files in proxy module. Expected that `api.id` is an atom, but when using files it's a string.
 
 <!-- ### Security -->
 

--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway/proxy.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway/proxy.ex
@@ -70,8 +70,8 @@ defmodule RigInboundGateway.Proxy do
 
   defp do_init_presence(config_path_or_json, state) do
     with {:ok, config} when is_list(config) <- Config.parse_json_env(config_path_or_json) do
-      Enum.each(config, fn api ->
-        Logger.info(fn -> "Reverse proxy: service #{api.id}" end)
+      Enum.each(config, fn %{"id" => id} = api ->
+        Logger.info(fn -> "Reverse proxy: service #{id}" end)
         api_with_default_values = set_default_api_values(api)
         state.tracker_mod.track(api["id"], api_with_default_values)
       end)


### PR DESCRIPTION
In master this would fail: `PROXY_CONFIG_FILE=proxy/proxy.test.json mix phx.server`