### PR TITLE
Fix kinesis forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Proxy] Parsing of JSON files in proxy module. Expected that `api.id` is an atom, but when using files it's a string.
+- [Kinesis] Parsing of incoming Kinesis messages to proper Cloud Event format.
 
 <!-- ### Security -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Proxy] Parsing of JSON files in proxy module. Expected that `api.id` is an atom, but when using files it's a string.
-- [Kinesis] Parsing of incoming Kinesis messages to proper Cloud Event format.
+- [Kinesis] Support for CloudEvents versions 0.1 and 0.2.
 - [Docs] Fixed channels example with latest RIG API changes.
 
 <!-- ### Security -->

--- a/apps/rig/lib/rig/event_stream/kinesis_to_filter.ex
+++ b/apps/rig/lib/rig/event_stream/kinesis_to_filter.ex
@@ -1,0 +1,31 @@
+defmodule Rig.EventStream.KinesisToFilter do
+  @moduledoc """
+  Consumes events and forwards them to the event filter by event type.
+
+  """
+
+  alias Rig.EventFilter
+  alias RigCloudEvents.CloudEvent
+
+  require Logger
+
+  # ---
+
+  def validate(conf), do: {:ok, conf}
+
+  # ---
+
+  def kinesis_handler(message) do
+    case CloudEvent.parse(message) do
+      {:ok, %CloudEvent{} = cloud_event} ->
+        Logger.debug(fn -> inspect(cloud_event.parsed) end)
+        EventFilter.forward_event(cloud_event)
+        :ok
+
+      {:error, :parse_error} ->
+        {:error, :non_cloud_events_not_supported, message}
+    end
+  rescue
+    err -> {:error, err, message}
+  end
+end

--- a/apps/rig_outbound_gateway/lib/rig_outbound_gateway/kinesis/java_client.ex
+++ b/apps/rig_outbound_gateway/lib/rig_outbound_gateway/kinesis/java_client.ex
@@ -6,10 +6,11 @@ defmodule RigOutboundGateway.Kinesis.JavaClient do
   """
   use Rig.Config, :custom_validation
   use GenServer
-  require Logger
 
-  alias Rig.EventFilter
+  alias Rig.EventStream.KinesisToFilter
   alias RigOutboundGateway.Kinesis.LogStream
+
+  require Logger
 
   @jinterface_version "1.8.1"
   @restart_delay_ms 20_000
@@ -117,8 +118,6 @@ defmodule RigOutboundGateway.Kinesis.JavaClient do
   def java_client_callback(data) do
     data[:body]
     |> Poison.decode!()
-    |> EventFilter.forward_event()
-
-    :ok
+    |> KinesisToFilter.kinesis_handler()
   end
 end


### PR DESCRIPTION
Fixed forwarding of Kinesis messages to client. Now it should properly parse message to cloud event format and forward to event filter.