### PR TITLE
https docu + updated cert file mounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validation errors for SSE & WS connections and the subscriptions endpoint should now be a lot more helpful. Also, the welcome event (after establishing a connection) now contains the list of errors (non-breaking change). For example, when passing an invalid JWT, the connection is established nevertheless (new behaviour), but the error is communicated in the welcome event. [#54](https://github.com/Accenture/reactive-interaction-gateway/issues/54)
 - The HTTPS certificate location has been changed from two mount-locations (rig_api/priv/cert & rig_inbound_gateway/priv/cert) to just one location rig/priv/cert. This means the OPS configuration needs to be changed in order to still support HTTPS. Additionally the selfsigned dev-certificate is not longer shipped with the docker image for security reasons [#151](https://github.com/Accenture/reactive-interaction-gateway/issues/151)
+- The HTTPS certificate can now be mounted to an absolute path independent of the applications /priv directory [#182](https://github.com/Accenture/reactive-interaction-gateway/issues/182)
 
 <!-- ### Deprecated -->
 

--- a/apps/rig/lib/rig/config.ex
+++ b/apps/rig/lib/rig/config.ex
@@ -129,7 +129,7 @@ defmodule Rig.Config do
 
   @spec from_file(String.t()) :: {:ok, any} | {:error, reason :: any}
   defp from_file(path) do
-    %{path: path, found?: false}
+    %{found?: false, path: path}
     |> check_path_as_is()
     |> check_relative_to_priv()
     |> case do
@@ -189,8 +189,18 @@ defmodule Rig.Config do
 
   # ---
 
+  @spec resolve_path(String.t()) :: Struing.t()
   defp resolve_path(path) do
-    :code.priv_dir(:rig) |> Path.join(path)
+    %{found?: false, path: path}
+    |> check_path_as_is()
+    |> check_relative_to_priv()
+    |> case do
+      %{found?: false} ->
+        Logger.error("Could not resolve path for HTTPS file: #{path}")
+
+      %{path: path} ->
+        path
+    end
   end
 
   # ---

--- a/docs/https.md
+++ b/docs/https.md
@@ -1,0 +1,35 @@
+---
+id: https
+title: HTTPS
+sidebar_label: HTTPS
+---
+
+## HTTPS/TLS
+
+In order to enable HTTPS, the `HTTPS_CERTFILE` and `HTTPS_KEYFILE` environment variables must be set. During development, this may be set to the self-signed certificate that comes with the repository:
+
+```bash
+$ export HTTPS_CERTFILE=cert/selfsigned.pem
+$ export HTTPS_KEYFILE=cert/selfsigned_key.pem
+$ mix phx.server
+```
+
+WARNING: only use the generated certificate for testing in a closed network environment, such as running a development RIG instance on localhost. For production, staging, or testing on the public internet, obtain a proper certificate, for example from [Let’s Encrypt](https://letsencrypt.org/).
+
+For production you should use proper HTTPS certificates instead (for that reason the Docker image comes without certificates).
+
+1. Create your own not-selfsigned certificate
+2. Store it on your machine
+3. Run the docker image by mounting the files as shown here:
+
+```bash
+$ docker run \
+  -v "$(pwd)"/cert/not-selfsigned.pem:/cert/not-selfsigned.pem \
+  -e HTTPS_CERTFILE=/cert/not-selfsigned.pem \
+  -v "$(pwd)"/cert/not-selfsigned_key.pem:/cert/not-selfsigned_key.pem \
+  -e HTTPS_KEYFILE=/cert/not-selfsigned_key.pem \
+  -p 4000:4000 -p 4010:4010 \
+  accenture/reactive-interaction-gateway
+```
+
+Refer to the [RIG operator guide](rig-ops-guide.md) to learn more about available configuration options.

--- a/docs/https.md
+++ b/docs/https.md
@@ -18,17 +18,18 @@ WARNING: only use the generated certificate for testing in a closed network envi
 
 For production you should use proper HTTPS certificates instead (for that reason the Docker image comes without certificates).
 
-1. Create your own not-selfsigned certificate
+1. Create your own certificate
 2. Store it on your machine
 3. Run the docker image by mounting the files as shown here:
 
 ```bash
 $ docker run \
-  -v "$(pwd)"/cert/not-selfsigned.pem:/cert/not-selfsigned.pem \
-  -e HTTPS_CERTFILE=/cert/not-selfsigned.pem \
-  -v "$(pwd)"/cert/not-selfsigned_key.pem:/cert/not-selfsigned_key.pem \
-  -e HTTPS_KEYFILE=/cert/not-selfsigned_key.pem \
+  -v "$(pwd)"/cert/own-certificate.pem:/cert/own-certificate.pem \
+  -e HTTPS_CERTFILE=/cert/own-certificate.pem \
+  -v "$(pwd)"/cert/own-certificate_key.pem:/cert/own-certificate_key.pem \
+  -e HTTPS_KEYFILE=/cert/own-certificate_key.pem \
   -p 4000:4000 -p 4010:4010 \
+  -p 4001:4001 -p 4011:4011 \
   accenture/reactive-interaction-gateway
 ```
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -33,6 +33,10 @@
         "title": "Metrics Details",
         "sidebar_label": "Metrics Details"
       },
+      "https": {
+        "title": "HTTPS",
+        "sidebar_label": "HTTPS"
+      },
       "rig-dev-guide": {
         "title": "Developer's Guide to the Reactive Interaction Gateway",
         "sidebar_label": "Developer's Guide"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -17,7 +17,8 @@
     ],
     "RIG in Production": [
       "rig-ops-guide",
-      "metrics-details"
+      "metrics-details",
+      "https"
     ],
     "Hacking the Source": [
       "rig-dev-guide"


### PR DESCRIPTION
Closes #182 

@kevinbader 
Could you have a look on this one? When I now run rig with docker + mounting the files as proposed in the new https.md I don't get any errors + as of logs also cowboy with correct port is started.

BUT: When i try to call rig with https I get a connection refused.

when I run rig using mix phx.server (using standard dev parameters) I'm able to call rig on https.

I'm not sure if I'm doing something wrong on mounting the files or missing some param on docker run? Or is it sth else? 