### PR TITLE
Swagger & Kafka group ID fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- [Docs] Added missing `id` field to swagger spec for `message` API.
 
 <!-- ### Security -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Docs] Added missing `id` field to swagger spec for `message` API.
+- [Kafka] Fixed random generation of group IDs. This led to wrong partition distribution when using multiple RIG nodes. Now consumers will have the same ID which can be changed via environment variable - defaults to `rig`.
 
 <!-- ### Security -->
 

--- a/apps/rig/config/config.exs
+++ b/apps/rig/config/config.exs
@@ -32,7 +32,8 @@ config :rig, Rig.EventStream.KafkaToFilter,
   # In case the private key is password protected:
   ssl_keyfile_pass: {:system, "KAFKA_SSL_KEYFILE_PASS", ""},
   # Credentials for SASL/Plain authentication. Example: "plain:myusername:mypassword"
-  sasl: {:system, "KAFKA_SASL", nil}
+  sasl: {:system, "KAFKA_SASL", nil},
+  group_id: {:system, "KAFKA_GROUP_ID", "rig"}
 
 config :rig, Rig.EventStream.KafkaToHttp,
   # The list of brokers, given by a comma-separated list of host:port items:
@@ -50,7 +51,8 @@ config :rig, Rig.EventStream.KafkaToHttp,
   # Credentials for SASL/Plain authentication. Example: "plain:myusername:mypassword"
   sasl: {:system, "KAFKA_SASL", nil},
   # HTTP endpoints to invoke for each Kafka message:
-  targets: {:system, :list, "FIREHOSE_KAFKA_HTTP_TARGETS", []}
+  targets: {:system, :list, "FIREHOSE_KAFKA_HTTP_TARGETS", []},
+  group_id: {:system, "KAFKA_GROUP_ID", "rig"}
 
 config :porcelain, driver: Porcelain.Driver.Basic
 

--- a/apps/rig_api/lib/rig_api/controllers/message_controller.ex
+++ b/apps/rig_api/lib/rig_api/controllers/message_controller.ex
@@ -60,6 +60,14 @@ defmodule RigApi.MessageController do
           description("The broadcasted CloudEvent according to the CloudEvents spec.")
 
           properties do
+            id(
+              :string,
+              "ID of the event. The semantics of this string are explicitly undefined to ease \
+              the implementation of producers. Enables deduplication.",
+              required: true,
+              example: "A database commit ID"
+            )
+
             specversion(
               :string,
               "The version of the CloudEvents specification which the event uses. This \

--- a/apps/rig_inbound_gateway/config/config.exs
+++ b/apps/rig_inbound_gateway/config/config.exs
@@ -113,7 +113,8 @@ config :rig, RigInboundGateway.ApiProxy.Handler.Kafka,
   sasl: {:system, "KAFKA_SASL", nil},
   request_topic: {:system, "PROXY_KAFKA_REQUEST_TOPIC", ""},
   cors: {:system, "CORS", "*"},
-  response_timeout: {:system, :integer, "PROXY_KAFKA_RESPONSE_TIMEOUT", 5_000}
+  response_timeout: {:system, :integer, "PROXY_KAFKA_RESPONSE_TIMEOUT", 5_000},
+  group_id: {:system, "KAFKA_GROUP_ID", "rig"}
 
 config :rig, RigInboundGateway.ApiProxy.Handler.Kinesis,
   kinesis_request_stream: {:system, "PROXY_KINESIS_REQUEST_STREAM", nil},

--- a/apps/rig_kafka/lib/rig_kafka/config.ex
+++ b/apps/rig_kafka/lib/rig_kafka/config.ex
@@ -51,7 +51,7 @@ defmodule RigKafka.Config do
       consumer_topics: Map.get(config, :consumer_topics, []),
       server_id: Map.get(config, :server_id) || String.to_atom("rig_kafka_#{uuid}"),
       client_id: Map.get(config, :client_id) || String.to_atom("brod_client_#{uuid}"),
-      group_id: Map.get(config, :group_id) || "brod_group_rig",
+      group_id: Map.get(config, :group_id),
       ssl: Map.get(config, :ssl),
       sasl: Map.get(config, :sasl)
     }

--- a/apps/rig_kafka/lib/rig_kafka/config.ex
+++ b/apps/rig_kafka/lib/rig_kafka/config.ex
@@ -51,7 +51,7 @@ defmodule RigKafka.Config do
       consumer_topics: Map.get(config, :consumer_topics, []),
       server_id: Map.get(config, :server_id) || String.to_atom("rig_kafka_#{uuid}"),
       client_id: Map.get(config, :client_id) || String.to_atom("brod_client_#{uuid}"),
-      group_id: Map.get(config, :group_id) || "brod_group_#{uuid}",
+      group_id: Map.get(config, :group_id) || "brod_group_rig",
       ssl: Map.get(config, :ssl),
       sasl: Map.get(config, :sasl)
     }

--- a/apps/rig_kafka/mix.exs
+++ b/apps/rig_kafka/mix.exs
@@ -39,7 +39,7 @@ defmodule RigKafka.MixProject do
       {:brod, "~> 3.7"},
       # For Kafka, partition from MurmurHash(key):
       {:murmur, "~> 1.0"},
-      # For generating client_id and group_id:
+      # For generating client_id:
       {:uuid, "~> 1.1"}
     ]
   end

--- a/apps/rig_kafka/test/rig_kafka_test.exs
+++ b/apps/rig_kafka/test/rig_kafka_test.exs
@@ -31,7 +31,8 @@ defmodule RigKafkaTest do
 
     Config.new(%{
       brokers: brokers,
-      consumer_topics: consumer_topics
+      consumer_topics: consumer_topics,
+      group_id: "rig"
     })
   end
 

--- a/docs/rig-ops-guide.md
+++ b/docs/rig-ops-guide.md
@@ -34,6 +34,7 @@ Variable&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 `JWT_ALG` | Algorithm used to sign and verify JSON web tokens. | "HS256"
 `JWT_SESSION_FIELD` | The JWT field that defines a "session", which is used for listing and killing/blacklisting sessions. What a session is depends on your application. For example, one might set `JWT_SESSION_FIELD` to the users' ID field, which would group all connections that belong to the same user to a single session - this way, blacklisting a session would mean killing all connections of a single user. The `JWT_SESSION_FIELD` is specified using the [JSON Pointer](https://tools.ietf.org/html/rfc6901) notation. Given that the JWT contains a user ID in its "userId" field, the configuration could look like this: `JWT_SESSION_FIELD=/userId`. | nil
 `KAFKA_BROKERS` | List of Kafka brokers RIG should connect to, delimited by comma (e.g., `localhost:9092,localhost:9093`). Usually it's enough to specify one broker and RIG will auto-discover rest of the Kafka cluster. | []
+`KAFKA_GROUP_ID` | Kafka group ID that will be used for all consumers. Ensures nodes will correctly distribute partitions. | "rig"
 `KAFKA_LOG_TOPIC` | Kafka topic for producer used to log HTTP requests going through RIG's API Proxy. | "rig-request-log"
 `KAFKA_RESTART_DELAY_MS` | If the connection to Kafka fails or cannot be established, RIG retries setting up the connection after `KAFKA_RESTART_DELAY_MS` milliseconds. | nil
 `KAFKA_SOURCE_TOPICS` | List of Kafka topics RIG will consume, delimited by comma. | ["rig"]

--- a/integration_tests/kafka_tests/run.sh
+++ b/integration_tests/kafka_tests/run.sh
@@ -22,7 +22,7 @@ while ! is_kafka_ready; do
     sleep 1
 done
 
-check whether Kafka is now ready or the loop has been aborted:
+# check whether Kafka is now ready or the loop has been aborted:
 is_kafka_ready || exit 1
 
 export KAFKA_BROKERS="${HOST}:${KAFKA_PORT_PLAIN}"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -37,10 +37,6 @@
         "title": "Metrics Details",
         "sidebar_label": "Metrics Details"
       },
-      "https": {
-        "title": "HTTPS",
-        "sidebar_label": "HTTPS"
-      },
       "rig-dev-guide": {
         "title": "Developer's Guide to the Reactive Interaction Gateway",
         "sidebar_label": "Developer's Guide"


### PR DESCRIPTION
- fixed missing id field for message swagger spec
- fixed random generation of Kafka group id

Test:
- `mix test` & integration tests should pass
- run rig locally - sending `/message` form `http://localhost:4010/swagger-ui` should work on ootb
- same should work from docker container

- run rig with Kafka => check consumer => all should have consumer group set to `rig` - can be changed via env var