### PR TITLE
Fix subscriptions endpoint for cluster setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Changed -->
 
+### Fixed
+
+- Fixed a bug that caused the subscriptions endpoint to return an internal server error when running RIG in a clustered setup. [#194](https://github.com/Accenture/reactive-interaction-gateway/issues/194)
+
 <!-- ### Deprecated -->
 
 <!-- ### Removed -->


### PR DESCRIPTION
The subscriptions endpoint relied on `Process.alive?`, which does not
work when a process lives on a remote node. This change replaces this
with `:rpc.pinfo/1`, which is the location-transparent version of the
`:erlang.process_info/1` call that underlies `Process.alive?`.

Closes #194 