### PR TITLE
Fixed missing CORS headers for Kafka/Kinesis proxy target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Docs] Added missing `id` field to swagger spec for `message` API.
 - [Kafka] Fixed random generation of group IDs. This led to wrong partition distribution when using multiple RIG nodes. Now consumers will have the same ID which can be changed via environment variable - defaults to `rig`.
 - [Proxy] When forwarding an HTTP request, the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) request header is now set to the `target_url` defined by the proxy configuration. [#188](https://github.com/Accenture/reactive-interaction-gateway/issues/188)
+- [Proxy] Added missing CORS headers for Kafka/Kinesis target type when not using `response_from`.
 
 <!-- ### Security -->
 

--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway/api_proxy/handler/kafka.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway/api_proxy/handler/kafka.ex
@@ -114,6 +114,8 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kafka do
         _ -> false
       end
 
+    conn = with_cors(conn)
+
     if wait_for_response? do
       wait_for_response(conn, response_from)
     else
@@ -165,7 +167,6 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kafka do
         )
 
         conn
-        |> with_cors()
         |> Conn.put_resp_content_type("application/json")
         |> Conn.send_resp(:ok, response)
     after
@@ -179,7 +180,6 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kafka do
         )
 
         conn
-        |> with_cors()
         |> Conn.send_resp(:gateway_timeout, "")
     end
   end

--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway/api_proxy/handler/kinesis.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway/api_proxy/handler/kinesis.ex
@@ -83,6 +83,8 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kinesis do
         _ -> false
       end
 
+    conn = with_cors(conn)
+
     if wait_for_response? do
       wait_for_response(conn, response_from)
     else
@@ -134,7 +136,6 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kinesis do
         )
 
         conn
-        |> with_cors()
         |> Conn.put_resp_content_type("application/json")
         |> Conn.send_resp(:ok, response)
     after
@@ -148,7 +149,6 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kinesis do
         )
 
         conn
-        |> with_cors()
         |> Conn.send_resp(:gateway_timeout, "")
     end
   end


### PR DESCRIPTION
Updated Kafka/Kinesis proxy handlers to properly attach CORS headers in all cases.