### PR TITLE
Support forwarding H/1 responses over H/2 connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug that caused the subscriptions endpoint to return an internal server error when running RIG in a clustered setup. [#194](https://github.com/Accenture/reactive-interaction-gateway/issues/194)
+- Support for forwarding HTTP/1.1 responses over a HTTP/2 connection by dropping connection-related HTTP headers. [#193](https://github.com/Accenture/reactive-interaction-gateway/issues/193)
 
 <!-- ### Deprecated -->
 


### PR DESCRIPTION
Support for forwarding HTTP/1.1 responses over a HTTP/2 connection by dropping connection-related HTTP headers.

Closes #193