### PR TITLE
213 - Allow to send async response using internal HTTP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Beta_ - Added Apache Avro support for consumer and producer as well as Kafka Schema Registry.
 - [Docs] Added new set of topics in documentation about Api Gateway, even streams and scaling.
 - [Docs] Added examples section to documentation website.
-- [API/Proxy] Added new `response_from` option -- `http_internal` together with new internal `POST` endpoint `/v1/responses`. You can send correlated response to `/v1/responses` and complete initial Proxy request.
+- [API/Proxy] Added new `response_from` option -- `http_async` together with new internal `POST` endpoint `/v1/responses`. You can send correlated response to `/v1/responses` and complete initial Proxy request. [#213](https://github.com/Accenture/reactive-interaction-gateway/issues/213)
 
 <!-- ### Changed -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Beta_ - Added Apache Avro support for consumer and producer as well as Kafka Schema Registry.
 - [Docs] Added new set of topics in documentation about Api Gateway, even streams and scaling.
 - [Docs] Added examples section to documentation website.
+- [API/Proxy] Added new `response_from` option -- `http_internal` together with new internal `POST` endpoint `/v1/responses`. You can send correlated response to `/v1/responses` and complete initial Proxy request.
 
 <!-- ### Changed -->
 
@@ -20,18 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug that caused the subscriptions endpoint to return an internal server error when running RIG in a clustered setup. [#194](https://github.com/Accenture/reactive-interaction-gateway/issues/194)
 - Support for forwarding HTTP/1.1 responses over a HTTP/2 connection by dropping connection-related HTTP headers. [#193](https://github.com/Accenture/reactive-interaction-gateway/issues/193)
-
-<!-- ### Deprecated -->
-
-<!-- ### Removed -->
-
-### Fixed
-
 - [Docs] Added missing `id` field to swagger spec for `message` API.
 - [Kafka] Fixed random generation of group IDs. This led to wrong partition distribution when using multiple RIG nodes. Now consumers will have the same ID which can be changed via environment variable - defaults to `rig`.
 - [Proxy] When forwarding an HTTP request, the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) request header is now set to the `target_url` defined by the proxy configuration. [#188](https://github.com/Accenture/reactive-interaction-gateway/issues/188)
 - [Docs] Fixed missing `swagger.json` file in production Docker image.
 - [Proxy] Added missing CORS headers for Kafka/Kinesis target type when not using `response_from`.
+
+<!-- ### Deprecated -->
+
+<!-- ### Removed -->
 
 <!-- ### Security -->
 

--- a/apps/rig_api/lib/rig_api/controllers/responses_controller.ex
+++ b/apps/rig_api/lib/rig_api/controllers/responses_controller.ex
@@ -1,0 +1,78 @@
+defmodule RigApi.ResponsesController do
+  require Logger
+
+  use RigApi, :controller
+  use PhoenixSwagger
+
+  alias Rig.Connection.Codec
+
+  action_fallback(RigApi.FallbackController)
+
+  swagger_path :create do
+    post("/v1/responses")
+    summary("Submit a message, to be sent to correlated reverse proxy request.")
+    description("Allows you to submit a message to RIG using a simple, \
+    synchronous call. Message will be sent to correlated reverse proxy request.")
+
+    parameters do
+      messageBody(
+        :body,
+        Schema.ref(:Response),
+        "Response",
+        required: true
+      )
+    end
+
+    response(202, "Accepted - message sent to correlated reverse proxy request")
+    response(400, "Bad Request: Failed to parse request body :parse-error")
+  end
+
+  @doc """
+  Accepts message to be sent to correlated HTTP process.
+
+  Note that body has to contain following field `"rig": { "correlation": "_id_" }`.
+  """
+  def create(conn, message) do
+    with {:ok, rig_metadata} <- Map.fetch(message, "rig"),
+         {:ok, correlation_id} <- Map.fetch(rig_metadata, "correlation"),
+         {:ok, deserialized_pid} <- Codec.deserialize(correlation_id),
+         {:ok, encoded_body} <- Jason.encode(message) do
+      Logger.debug(fn ->
+        "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
+      end)
+
+      send(deserialized_pid, {:response_received, encoded_body})
+      send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
+    else
+      err ->
+        Logger.warn(fn -> "Parse error #{inspect(err)} for #{inspect(message)}" end)
+
+        conn
+        |> put_status(:bad_request)
+        |> text("Failed to parse request body: #{inspect(err)}")
+    end
+  end
+
+  def swagger_definitions do
+    %{
+      Response:
+        swagger_schema do
+          title("Response object")
+          description("A Response object that will be sent to correlated reverse proxy request.")
+
+          properties do
+            rig(
+              Schema.new do
+                properties do
+                  correlation(:string, "Correlation ID",
+                    required: true,
+                    example: "g2dkAA1ub25vZGVAbm9ob3N0AAADxwAAAAAA"
+                  )
+                end
+              end
+            )
+          end
+        end
+    }
+  end
+end

--- a/apps/rig_api/lib/rig_api/controllers/responses_controller.ex
+++ b/apps/rig_api/lib/rig_api/controllers/responses_controller.ex
@@ -17,8 +17,8 @@ defmodule RigApi.ResponsesController do
     parameters do
       messageBody(
         :body,
-        Schema.ref(:Response),
-        "Response",
+        Schema.ref(:CloudEvent),
+        "CloudEvent",
         required: true
       )
     end
@@ -57,10 +57,46 @@ defmodule RigApi.ResponsesController do
     %{
       Response:
         swagger_schema do
-          title("Response object")
-          description("A Response object that will be sent to correlated reverse proxy request.")
+          title("CloudEvent")
+          description("The CloudEvent that will be sent to correlated reverse proxy request.")
 
           properties do
+            id(
+              :string,
+              "ID of the event. The semantics of this string are explicitly undefined to ease \
+              the implementation of producers. Enables deduplication.",
+              required: true,
+              example: "A database commit ID"
+            )
+
+            specversion(
+              :string,
+              "The version of the CloudEvents specification which the event uses. This \
+              enables the interpretation of the context. Compliant event producers \
+              MUST use a value of 0.2 when referring to this version of the \
+              specification.",
+              required: true,
+              example: "0.2"
+            )
+
+            source(
+              :string,
+              "This describes the event producer. Often this will include information such \
+              as the type of the event source, the organization publishing the event, the \
+              process that produced the event, and some unique identifiers. The exact syntax \
+              and semantics behind the data encoded in the URI is event producer defined.",
+              required: true,
+              example: "/cloudevents/spec/pull/123"
+            )
+
+            type(
+              :string,
+              "Type of occurrence which has happened. Often this attribute is used for \
+              routing, observability, policy enforcement, etc.",
+              required: true,
+              example: "com.example.object.delete.v2"
+            )
+
             rig(
               Schema.new do
                 properties do

--- a/apps/rig_api/lib/rig_api/router.ex
+++ b/apps/rig_api/lib/rig_api/router.ex
@@ -10,6 +10,8 @@ defmodule RigApi.Router do
 
     resources("/messages", MessageController, only: [:create])
 
+    resources("/responses", ResponsesController, only: [:create])
+
     scope "/users" do
       get("/", ChannelsController, :list_channels)
       get("/:user/sessions", ChannelsController, :list_channel_sessions)

--- a/apps/rig_inbound_gateway/config/config.exs
+++ b/apps/rig_inbound_gateway/config/config.exs
@@ -95,7 +95,7 @@ config :rig, RigInboundGateway.ApiProxy.Handler.Http,
   cors: {:system, "CORS", "*"},
   kafka_response_timeout: {:system, :integer, "PROXY_KAFKA_RESPONSE_TIMEOUT", 5_000},
   kinesis_response_timeout: {:system, :integer, "PROXY_KINESIS_RESPONSE_TIMEOUT", 5_000},
-  http_response_timeout: {:system, :integer, "PROXY_HTTP_RESPONSE_TIMEOUT", 5_000}
+  http_async_response_timeout: {:system, :integer, "PROXY_HTTP_ASYNC_RESPONSE_TIMEOUT", 5_000}
 
 config :rig, RigInboundGateway.ApiProxy.Handler.Kafka,
   # The list of brokers, given by a comma-separated list of host:port items:

--- a/apps/rig_inbound_gateway/config/config.exs
+++ b/apps/rig_inbound_gateway/config/config.exs
@@ -94,7 +94,8 @@ config :rig, RigInboundGateway.ApiProxy.Router,
 config :rig, RigInboundGateway.ApiProxy.Handler.Http,
   cors: {:system, "CORS", "*"},
   kafka_response_timeout: {:system, :integer, "PROXY_KAFKA_RESPONSE_TIMEOUT", 5_000},
-  kinesis_response_timeout: {:system, :integer, "PROXY_KINESIS_RESPONSE_TIMEOUT", 5_000}
+  kinesis_response_timeout: {:system, :integer, "PROXY_KINESIS_RESPONSE_TIMEOUT", 5_000},
+  http_response_timeout: {:system, :integer, "PROXY_HTTP_RESPONSE_TIMEOUT", 5_000}
 
 config :rig, RigInboundGateway.ApiProxy.Handler.Kafka,
   # The list of brokers, given by a comma-separated list of host:port items:

--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway/api_proxy/handler/http.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway/api_proxy/handler/http.ex
@@ -3,7 +3,13 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
   Handles requests for HTTP targets.
 
   """
-  use Rig.Config, [:cors, :kafka_response_timeout, :kinesis_response_timeout]
+  use Rig.Config, [
+    :cors,
+    :kafka_response_timeout,
+    :kinesis_response_timeout,
+    :http_response_timeout
+  ]
+
   require Logger
   alias HTTPoison
   alias Plug.Conn
@@ -97,6 +103,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
       case response_from do
         "kafka" -> conf.kafka_response_timeout
         "kinesis" -> conf.kinesis_response_timeout
+        "http_internal" -> conf.http_response_timeout
       end
 
     receive do

--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway/api_proxy/handler/http.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway/api_proxy/handler/http.ex
@@ -7,7 +7,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
     :cors,
     :kafka_response_timeout,
     :kinesis_response_timeout,
-    :http_response_timeout
+    :http_async_response_timeout
   ]
 
   require Logger
@@ -103,7 +103,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
       case response_from do
         "kafka" -> conf.kafka_response_timeout
         "kinesis" -> conf.kinesis_response_timeout
-        "http_internal" -> conf.http_response_timeout
+        "http_async" -> conf.http_async_response_timeout
       end
 
     receive do

--- a/apps/rig_tests/test/proxy/response_from/async_http_test.exs
+++ b/apps/rig_tests/test/proxy/response_from/async_http_test.exs
@@ -1,6 +1,6 @@
-defmodule RigTests.Proxy.ResponseFrom.HttpTest do
+defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
   @moduledoc """
-  If `response_from` is not set, the response is taken from the proxied request.
+  If `response_from` is set to http_async, the response is taken from internal HTTP endpoint /v1/responses
 
   Note that `test_with_server` sets up an HTTP server mock, which is then configured
   using the `route` macro.
@@ -9,24 +9,41 @@ defmodule RigTests.Proxy.ResponseFrom.HttpTest do
   use ExUnit.Case, async: false
 
   import FakeServer
+  import Plug.Conn, only: [put_req_header: 3]
+  import Phoenix.ConnTest, only: [post: 3, build_conn: 0]
 
   alias FakeServer.Response
 
+  @endpoint RigApi.Endpoint
   @api_port Confex.fetch_env!(:rig_api, RigApi.Endpoint)[:http][:port]
   @proxy_port Confex.fetch_env!(:rig_inbound_gateway, RigInboundGatewayWeb.Endpoint)[:http][:port]
 
-  test_with_server "Given response_from is not set, the http response is forwarded as-is." do
-    test_name = "proxy-http-sync-response"
+  test_with_server "Given response_from is set to http_async, the http response is taken from the internal HTTP endpoint." do
+    test_name = "proxy-http-response-from-http-internal"
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
     endpoint_path = "/#{endpoint_id}"
-    sync_response = %{"this response" => "is forwarded as-is to the client."}
+    sync_response = %{"this response" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
 
-    route(
-      endpoint_path,
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      event =
+        Jason.encode!(%{
+          specversion: "0.2",
+          type: "rig.async-response",
+          source: "fake-service",
+          id: "1",
+          rig: %{correlation: correlation_id},
+          data: async_response
+        })
+
+      build_conn()
+      |> put_req_header("content-type", "application/json;charset=utf-8")
+      |> post("/v1/responses", event)
+
       Response.ok!(sync_response, %{"content-type" => "application/json"})
-    )
+    end)
 
     # We register the endpoint with the proxy:
     rig_api_url = "http://localhost:#{@api_port}/v1/apis"
@@ -42,9 +59,9 @@ defmodule RigTests.Proxy.ResponseFrom.HttpTest do
               %{
                 id: endpoint_id,
                 type: "http",
-                secured: false,
                 method: "GET",
-                path: endpoint_path
+                path: endpoint_path,
+                response_from: "http_async"
               }
             ]
           }
@@ -67,7 +84,9 @@ defmodule RigTests.Proxy.ResponseFrom.HttpTest do
     assert FakeServer.hits() == 1
     # ...the connection is closed and the status is OK:
     assert res_status == 200
-    # ...the response received is exactly what the service mock returned:
-    assert Jason.decode!(res_body) == sync_response
+    # ...the client never saw the http response:
+    assert Jason.decode!(res_body) != sync_response
+    # ...but the client got the response sent to the HTTP internal endpoint:
+    assert Jason.decode!(res_body)["data"] == async_response
   end
 end

--- a/apps/rig_tests/test/proxy/response_from/http_test.exs
+++ b/apps/rig_tests/test/proxy/response_from/http_test.exs
@@ -1,15 +1,21 @@
 defmodule RigTests.Proxy.ResponseFrom.HttpTest do
   @moduledoc """
   If `response_from` is not set, the response is taken from the proxied request.
+  If `response_from` is set to http_internal, the response is taken from internal HTTP endpoint /v1/responses
 
   Note that `test_with_server` sets up an HTTP server mock, which is then configured
   using the `route` macro.
   """
   # cause FakeServer opens a port:
   use ExUnit.Case, async: false
+
   import FakeServer
+  import Plug.Conn, only: [put_req_header: 3]
+  import Phoenix.ConnTest, only: [post: 3, build_conn: 0]
+
   alias FakeServer.Response
 
+  @endpoint RigApi.Endpoint
   @api_port Confex.fetch_env!(:rig_api, RigApi.Endpoint)[:http][:port]
   @proxy_port Confex.fetch_env!(:rig_inbound_gateway, RigInboundGatewayWeb.Endpoint)[:http][:port]
 
@@ -67,5 +73,77 @@ defmodule RigTests.Proxy.ResponseFrom.HttpTest do
     assert res_status == 200
     # ...the response received is exactly what the service mock returned:
     assert Jason.decode!(res_body) == sync_response
+  end
+
+  test_with_server "Given response_from is set to http_internal, the http response is taken from the internal HTTP endpoint." do
+    test_name = "proxy-http-response-from-http-internal"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"this response" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      event =
+        Jason.encode!(%{
+          specversion: "0.2",
+          type: "rig.async-response",
+          source: "fake-service",
+          id: "1",
+          rig: %{correlation: correlation_id},
+          data: async_response
+        })
+
+      build_conn()
+      |> put_req_header("content-type", "application/json;charset=utf-8")
+      |> post("/v1/responses", event)
+
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v1/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                type: "http",
+                method: "GET",
+                path: endpoint_path,
+                response_from: "http_internal"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
+    # ...the connection is closed and the status is OK:
+    assert res_status == 200
+    # ...the client never saw the http response:
+    assert Jason.decode!(res_body) != sync_response
+    # ...but the client got the response sent to the HTTP internal endpoint:
+    assert Jason.decode!(res_body)["data"] == async_response
   end
 end

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -196,9 +196,16 @@ As an alternative you can set `response_from` to `http_async`. This means that c
 
 ```json
 {
+  "id": "1",
+  "specversion": "0.2",
+  "source": "my-service",
+  "type": "com.example",
   "rig": {
     "correlation": "_id_"
   },
+  "data": {
+    ...
+  }
   ...
 }
 ```

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -192,7 +192,7 @@ Configuration of such API endpoint might look like this:
 
 > Note the presence of `response_from` field. This tells RIG to wait for different event with the same correlation ID.
 
-As an alternative you can set `response_from` to `http_internal`. This means that correlated response has to be sent to internal `:4010/v1/responses` `POST` endpoint with a body like this:
+As an alternative you can set `response_from` to `http_async`. This means that correlated response has to be sent to internal `:4010/v1/responses` `POST` endpoint with a body like this:
 
 ```json
 {

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -192,6 +192,17 @@ Configuration of such API endpoint might look like this:
 
 > Note the presence of `response_from` field. This tells RIG to wait for different event with the same correlation ID.
 
+As an alternative you can set `response_from` to `http_internal`. This means that correlated response has to be sent to internal `:4010/v1/responses` `POST` endpoint with a body like this:
+
+```json
+{
+  "rig": {
+    "correlation": "_id_"
+  },
+  ...
+}
+```
+
 > __NOTE:__ Kinesis doesn't support `response_from` field yet.
 
 ## Auth

--- a/docs/metrics-details.md
+++ b/docs/metrics-details.md
@@ -34,6 +34,7 @@ Following Labels are provided:
 - **response_from** - Where the response is provided from. Grabbed from proxy config. Following possible values:
   - `http`
   - `kafka`
+  - `http_internal`
   - `N/A` - Not applicable, e.g., the request path is not configured.
 - **status** - The *internal* status for the request. Attention: this status only tracks the internal rig process status. Once forwarded we track as "ok". We expect that called services are monitored on it's own. Following possible status codes:
   - `ok` - Forwarded successfully.

--- a/docs/metrics-details.md
+++ b/docs/metrics-details.md
@@ -34,7 +34,7 @@ Following Labels are provided:
 - **response_from** - Where the response is provided from. Grabbed from proxy config. Following possible values:
   - `http`
   - `kafka`
-  - `http_internal`
+  - `http_async`
   - `N/A` - Not applicable, e.g., the request path is not configured.
 - **status** - The *internal* status for the request. Attention: this status only tracks the internal rig process status. Once forwarded we track as "ok". We expect that called services are monitored on it's own. Following possible status codes:
   - `ok` - Forwarded successfully.

--- a/docs/rig-ops-guide.md
+++ b/docs/rig-ops-guide.md
@@ -60,6 +60,7 @@ Variable&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 `NODE_COOKIE` | Erlang cookie used in distributed mode, so nodes in cluster can communicate between each other. | nil
 `NODE_HOST` | Erlang hostname for given node, used to build Erlang long-name `rig@NODE_HOST`. This value is used by Erlang's distributed mode, so nodes can see each other. | nil
 `PROXY_CONFIG_FILE` | Configuration JSON file with initial API definition for API Proxy. Use this variable to pass either a path to a JSON file, or the JSON string itself. A path can be given in absolute or in relative form (e.g., `proxy/your_json_file.json`). If given in relative form, the working directory is one of RIG's `priv` dirs (e.g., `/opt/sites/rig/lib/rig_inbound_gateway-2.0.2/priv/` in a Docker container). | nil
+`PROXY_HTTP_RESPONSE_TIMEOUT` | In case an endpoint has `target` set to `http` and `response_from` set to `http_internal`, this is the maximum delay between an HTTP request and the corresponding HTTP response message. | 5000
 `PROXY_RECV_TIMEOUT` | Timeout used when receiving a response for a forwarded/proxied request. | 5000
 `PROXY_KAFKA_RESPONSE_TOPICS` | Kafka topic for acknowledging Kafka sync events from proxy by correlation ID | ["rig-proxy-response"]
 `PROXY_KAFKA_REQUEST_AVRO` | Avro schema name for events published from proxy. | ""

--- a/docs/rig-ops-guide.md
+++ b/docs/rig-ops-guide.md
@@ -60,7 +60,7 @@ Variable&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 `NODE_COOKIE` | Erlang cookie used in distributed mode, so nodes in cluster can communicate between each other. | nil
 `NODE_HOST` | Erlang hostname for given node, used to build Erlang long-name `rig@NODE_HOST`. This value is used by Erlang's distributed mode, so nodes can see each other. | nil
 `PROXY_CONFIG_FILE` | Configuration JSON file with initial API definition for API Proxy. Use this variable to pass either a path to a JSON file, or the JSON string itself. A path can be given in absolute or in relative form (e.g., `proxy/your_json_file.json`). If given in relative form, the working directory is one of RIG's `priv` dirs (e.g., `/opt/sites/rig/lib/rig_inbound_gateway-2.0.2/priv/` in a Docker container). | nil
-`PROXY_HTTP_RESPONSE_TIMEOUT` | In case an endpoint has `target` set to `http` and `response_from` set to `http_internal`, this is the maximum delay between an HTTP request and the corresponding HTTP response message. | 5000
+`PROXY_HTTP_ASYNC_RESPONSE_TIMEOUT` | In case an endpoint has `target` set to `http` and `response_from` set to `http_async`, this is the maximum delay between an HTTP request and the corresponding async HTTP response message. | 5000
 `PROXY_RECV_TIMEOUT` | Timeout used when receiving a response for a forwarded/proxied request. | 5000
 `PROXY_KAFKA_RESPONSE_TOPICS` | Kafka topic for acknowledging Kafka sync events from proxy by correlation ID | ["rig-proxy-response"]
 `PROXY_KAFKA_REQUEST_AVRO` | Avro schema name for events published from proxy. | ""

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1950,7 +1950,7 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-docusaurus@^1.5.1:
+docusaurus@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.9.0.tgz#cb670d70c7bdabd9d2f6e26cd697b50bb4f28bfe"
   integrity sha512-FyZ7Bk82PB5cE3xWnO/lAH41T4UkY68ME+pHmhCXveZs+/cjaH5F7DZGlasf+JFeixYjnQvcHWc6ugw/cDB9Ig==


### PR DESCRIPTION
## Description

Added new internal `POST` endpoint `/v1/responses` to ack pending reverse proxy request. Added new `response_from` option `http_internal` to await ack from mentioned endpoint.

Closes #213 

## What to look out for

- Check docs and swagger
- Check naming - not sure if `http_internal` is the best choice, but didn't think about anything better, short and clear enough for everyone
- Check implementation and integration test (decided to put it alongside existing `http` scenario)
- @chadmott verify if following solution fulfils your needs

You can also test it via:

```bash
# terminal 1
config="[{\"id\":\"my-service\",\"version_data\":{\"default\":{\"endpoints\":[{\"id\":\"my-endpoint\",\"method\":\"GET\",\"path\":\"\/http\",\"response_from\":\"http_internal\"}]}},\"proxy\":{\"use_env\":true,\"target_url\":\"API_HOST\",\"port\":3000}}]"
# terminal 1
PROXY_CONFIG_FILE="$config" PROXY_HTTP_RESPONSE_TIMEOUT=30000 mix phx.server
# terminal 2
node examples/api-gateway/service.js
# terminal 3
curl "http://localhost:4000/http"
# terminal 4 - copy&paste correlation ID from terminal 2
curl -X POST "http://localhost:4010/v1/responses" -H "accept: application/json" -H "content-type: application/json" -d "{ \"rig\": { \"correlation\": \"g2dkAA1ub25vZGVAbm9ob3N0AAADpgAAAAAA\" }}"
```

## Process

The goal is to improve not only the code in this PR but also our skills! The "rules":

- The review is considered "done" as soon as all reviewers have added their review, and all their comments have been addressed.
- For knowledge-sharing reviews, each reviewer should "approve" the PR after studying its content.
- After the approval, the merge is concluded by the developer.

Have fun!
