### PR TITLE
Fix missing request body for external subscription check

### DIFF
--- a/apps/rig/lib/rig/subscriptions/parser/json.ex
+++ b/apps/rig/lib/rig/subscriptions/parser/json.ex
@@ -37,6 +37,11 @@ defmodule RIG.Subscriptions.Parser.JSON do
         %DecodeError{error: "invalid JSON encoding at position #{pos}", json: data}
         |> Result.err()
 
+      # In a request body, the subscriptions are put into a prop:
+      {:ok, %{"subscriptions" => decoded}} when is_list(decoded) ->
+        parse_subscriptions(decoded)
+
+      # In request params, the subscriptions are given directly:
       {:ok, decoded} when is_list(decoded) ->
         parse_subscriptions(decoded)
 

--- a/apps/rig_inbound_gateway/lib/rig_inbound_gateway_web/v1/subscription_controller.ex
+++ b/apps/rig_inbound_gateway/lib/rig_inbound_gateway_web/v1/subscription_controller.ex
@@ -85,8 +85,9 @@ defmodule RigInboundGatewayWeb.V1.SubscriptionController do
          {:ok, body, conn} <- BodyReader.read_full_body(conn),
          {:ok, json} <- Jason.decode(body),
          {:parse, %{"subscriptions" => subscriptions}} <- {:parse, json} do
-      Plug.Conn.assign(conn, :body, body)
-      Plug.Conn.assign(conn, :subscriptions, subscriptions)
+      conn
+      |> Plug.Conn.assign(:body, body)
+      |> Plug.Conn.assign(:subscriptions, subscriptions)
     else
       {:parse, json} ->
         message = """


### PR DESCRIPTION
## Description

When using an external service to authorize subscriptions, this makes sure the subscription body is actually passed in the request body.

Bug report on Slack:

> Piotr Kłoskowski 6:25 PM
looks like subscription parameters aren’t being passed to body:
request: %HTTPoison.Request{body: "", headers: [{"content-type", "application/json; charset=utf-8"}, {"authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6Im1pa2UiLCJpYXQiOjE1NjUyODEyOTYsImV4cCI6MTU2NTI4NDg5Nn0.J_a8p0MMgrSQ6n-oJ29BZ4FhR429DAxAiO8FUpPNifM"}], method: :post, options: [], params: %{}, url: "http://validator/"}, request_url: "http://validator/", status_code: 500}
Validator:
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Note that there is no Changelog entry as this feature hasn't been released yet.