### PR TITLE
WIP: 154 Metadata endpoint stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ erl_crash.dump
 /.elixir_ls/
 *~
 *.orig
+
+*.iml___jb_old___
+
+*.iml
+
+.idea/

--- a/config/config.exs
+++ b/config/config.exs
@@ -118,7 +118,7 @@ config :rig, Rig.Discovery,
   dns_name: {:system, "DNS_NAME", "localhost"}
 
 config :rig, RigInboundGatewayWeb.V1.MetadataController,
-  indexed_metadata: ["userid"]
+  indexed_metadata: ["userid", "locale"]
 
 import_config "#{Mix.env()}.exs"
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -118,7 +118,11 @@ config :rig, Rig.Discovery,
   dns_name: {:system, "DNS_NAME", "localhost"}
 
 config :rig, RigInboundGatewayWeb.V1.MetadataController,
-  indexed_metadata: ["userid", "locale"]
+  jwt_fields: %{"sub" => "userid"},
+  indexed_metadata: ["userid"]
+  # TODO: If needed, check jwt values against metadata values; error and return 404 if they don't match; lo prio; current state: if fields don't match, jwt is prio and metadata value for a specific key gets overwritten
+  # has_compare: false
+  # compare_strict: %{"jwt/userid" => "meta/userid"}
 
 import_config "#{Mix.env()}.exs"
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -117,6 +117,9 @@ config :rig, Rig.Discovery,
   discovery_type: {:system, "DISCOVERY_TYPE", nil},
   dns_name: {:system, "DNS_NAME", "localhost"}
 
+config :rig, RigInboundGatewayWeb.V1.MetadataController,
+  indexed_metadata: ["userid"]
+
 import_config "#{Mix.env()}.exs"
 
 import_config "rig_api/config.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -118,7 +118,7 @@ config :rig, Rig.Discovery,
   dns_name: {:system, "DNS_NAME", "localhost"}
 
 config :rig, RigInboundGatewayWeb.V1.MetadataController,
-  jwt_fields: %{"sub" => "userid"},
+  jwt_fields: %{"userid" => "sub"},
   indexed_metadata: ["userid"]
   # TODO: If needed, check jwt values against metadata values; error and return 404 if they don't match; lo prio; current state: if fields don't match, jwt is prio and metadata value for a specific key gets overwritten
   # has_compare: false

--- a/lib/rig_inbound_gateway_web/connection_init.ex
+++ b/lib/rig_inbound_gateway_web/connection_init.ex
@@ -40,7 +40,7 @@ defmodule RigInboundGatewayWeb.ConnectionInit do
         %{auth_tokens: [{"bearer", jwt}]} -> jwt
       end
 
-    # TODO: EVENT: SETUP 
+    # TODO: EVENT: SETUP
 
     with {:ok, jwt_subs} <-
            Subscriptions.from_token(jwt),

--- a/lib/rig_inbound_gateway_web/connection_init.ex
+++ b/lib/rig_inbound_gateway_web/connection_init.ex
@@ -40,6 +40,8 @@ defmodule RigInboundGatewayWeb.ConnectionInit do
         %{auth_tokens: [{"bearer", jwt}]} -> jwt
       end
 
+    # TODO: EVENT: SETUP 
+
     with {:ok, jwt_subs} <-
            Subscriptions.from_token(jwt),
          true = String.starts_with?(request.content_type, "application/json"),

--- a/lib/rig_inbound_gateway_web/router.ex
+++ b/lib/rig_inbound_gateway_web/router.ex
@@ -19,6 +19,9 @@ defmodule RigInboundGatewayWeb.Router do
 
         # The SSE handler is implemented using Cowboy's loop handler behaviour and set
         # up using the Cowboy dispatch configuration; see the `config.exs` file.
+
+        metadata_url = "/:connection_id/metadata"
+        put(metadata_url, MetadataController, :set_metadata)
       end
 
       # Unlike SSE & WS handlers, the LP handler is implemented using plug

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -70,18 +70,16 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
          {:parse, %{"metadata" => metadata}} <- {:parse, json},
          {:idx, true} <- {:idx, contains_idx(metadata)} do
 
-      IO.inspect metadata
+      IO.puts inspect(metadata)
 
       send_resp(conn, :no_content, "")
     else
       {:idx, false} ->
-        
         send_resp(conn, :bad_request, """
         Metadata doesn't contain indexed fields.
         """)
 
       {:parse, json} ->
-
         send_resp(conn, :bad_request, """
         Expected field "metadata" is not present.
 
@@ -90,7 +88,6 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
         """)
 
       error ->
-
         send_resp(conn, :bad_request, """
         Expected JSON encoded body.
 

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -14,7 +14,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
 
   require Logger
 
-  @spec set_metadata( conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
+  @spec set_metadata(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
   def set_metadata(
       %{method: "PUT"} = conn,
       %{

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -1,6 +1,6 @@
 defmodule RigInboundGatewayWeb.V1.MetadataController do
   @moduledoc """
-  Handles inbound metadata sets and the indexing and distribution of metadata 
+  Handles inbound metadata sets and the indexing and distribution of metadata
   """
   use RigInboundGatewayWeb, :controller
 
@@ -21,7 +21,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
   Sets metadata KV pairs for an existing connection, replacing previous metadata sets.
 
   There may be indexed metadata pairs defined. If a metadata set does not contain these indexed keys, it cannot be accepted.
-  
+
   ## Example
 
   Metadata set that contains a user ID, locale and timezone:
@@ -34,7 +34,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
         }
       }
 
-  In this example, the field "userid" might be indexed. In this case, the connection token would get associated with the value of the "userid" field (it will be possible to automatically take the user id from the JWT token (so that it cannot be changed by any other way) and index that; this will be serverside configuration). 
+  In this example, the field "userid" might be indexed. In this case, the connection token would get associated with the value of the "userid" field (it will be possible to automatically take the user id from the JWT token (so that it cannot be changed by any other way) and index that; this will be serverside configuration).
   In addition to that, the value of the "userid", "locale" and "timezone" fields would get associated to the connection token.
 
   To sum it up: the connection token is indexed by default, while all other fields can be indexed by configuration.
@@ -42,17 +42,17 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
   So the association would look like so:
 
       userid -> connection token
-      
+
       conection token ->
         userid
         locale
         timezone
 
-  All indexed fields are then being propagated to all other instances so they know where to find the corresponding metadata.
+  All indexed fields are then being propagated to all other instances, so they know where to find the corresponding metadata.
 
   ## Example
 
-  A user connects to RIG 1 and sends the metadata fields from above to RIG 1. RIG 1 would propagate the connection token and the userid along with the RIG instance ID to all other RIG instances.
+  A user connects to RIG 1 and sends the metadata fields from above to RIG 1. RIG 1 would propagate the connection token and the userid along with the RIG instance ID to all other RIG instances (via gen_tcp, preferably).
   If someone were to access the metadata of a user from RIG 3, RIG 3 would know where to find the metadata, ask RIG 1 for it and return the metadata set.
 
   """
@@ -64,7 +64,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
       }
   ) do
     IO.puts "REACHED SET METADATA"
-    IO.puts(BodyReader.read_full_body(conn) |> elem(1))
+    IO.puts(inspect(BodyReader.read_full_body(conn)))
 
     send_resp(conn, :no_content, "")
   end

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -3,6 +3,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
   Handles inbound metadata sets and the indexing and distribution of metadata
   """
   use RigInboundGatewayWeb, :controller
+  use Rig.Config, [:indexed_metadata]
 
   alias Result
 
@@ -98,8 +99,9 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
   end
 
   def contains_idx(metadata) do
-    # TODO: Actually check this by configuration
-    Enum.any?(metadata, fn x -> (x |> elem(0)) === "userid" end)
+    conf = config()
+    metadata_keys = Enum.map(metadata, fn x -> x |> elem(0) end)
+    Enum.all?(conf.indexed_metadata, fn x -> Enum.member?(metadata_keys, x) end)
   end
 
 end

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -100,7 +100,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
         message = """
         Metadata doesn't contain indexed fields.
         """
-        {:error, metadata}
+        {:error, message}
       end
     end
   end
@@ -124,7 +124,10 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
       end)
 
       # Get values from JWT
-      for {key, jwt_key} <- metadata_from_jwt, jwt_val = claims[jwt_key], into: %{}, do: {key, jwt_val}
+      for {key, jwt_key} <- metadata_from_jwt,
+        jwt_val = claims[jwt_key],
+        into: %{},
+        do: {key, jwt_val}
     else
       {:error, _} ->
         %{}
@@ -135,7 +138,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
 
   defp extract_metadata_from_json(conn) do
     with {"application", "json"} <- content_type(conn),
-         {:ok, body, conn} <- BodyReader.read_full_body(conn),
+         {:ok, body, _conn} <- BodyReader.read_full_body(conn),
          {:ok, json} <- Jason.decode(body),
          {:parse, %{"metadata" => metadata}} <- {:parse, json} do
       {:ok, metadata}

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -83,32 +83,44 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
   # ---
 
   defp extract_metadata(conn) do
-    {json_metadata_err, json_metadata} = extract_metadata_from_json(conn)
-    jwt_metadata = extract_metadata_from_jwt(conn)
+    with {:ok, body, _conn} <- BodyReader.read_full_body(conn) do
+      {json_metadata_err, json_metadata} = body |> extract_metadata_from_json()
+      {_, jwt_metadata} = Map.get(conn.assigns, :auth_tokens, []) |> extract_metadata_from_jwt()
 
-    if json_metadata_err === :error do
-      {:error, json_metadata}
-    else
-      # Merge values from metadata with the values from JWT, prioritizing JWT values
-      metadata = Map.merge(json_metadata, jwt_metadata)
-
-      # Check if metadata contains all the indexed fields; if not: send back a bad request
-      # This needs to be done here because now the values from the JWT got inserted
-      if has_required_indices?(metadata) do
-        {:ok, metadata}
+      if json_metadata_err === :error do
+        {:error, json_metadata}
       else
-        message = """
-        Metadata doesn't contain indexed fields.
-        """
-        {:error, message}
+        # Merge values from metadata with the values from JWT, prioritizing JWT values
+        metadata = Map.merge(json_metadata, jwt_metadata)
+
+        # Check if metadata contains all the indexed fields; if not: send back a bad request
+        # This needs to be done here because now the values from the JWT got inserted
+        if has_required_indices?(metadata) do
+          {:ok, metadata}
+        else
+          message = """
+          Metadata doesn't contain indexed fields.
+          """
+          {:error, message}
+        end
       end
+    else
+      error ->
+        message = """
+        Expected JSON encoded body.
+
+        Technical info:
+        #{inspect(error)}
+        """
+
+        {:error, message}
     end
   end
 
   # ---
 
-  defp extract_metadata_from_jwt(conn) do
-    with {:ok, claims} <- Map.get(conn.assigns, :auth_tokens, [])
+  def extract_metadata_from_jwt(auth_tokens) do
+    with {:ok, claims} <- auth_tokens
     |> Enum.map(fn
       {"bearer", token} -> JWT.parse_token(token)
       _ -> {:ok, %{}}
@@ -116,7 +128,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
     |> Result.list_to_result()
     |> Result.map_err(fn decode_errors -> {:error, decode_errors} end) do
       conf = config()
-      metadata_from_jwt = conf.jwt_fields
+      jwt_metadata_mapping = conf.jwt_fields
 
       # Merge the list of claims into a single map
       claims = Enum.reduce(claims, fn x, y ->
@@ -124,22 +136,20 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
       end)
 
       # Get values from JWT
-      for {key, jwt_key} <- metadata_from_jwt,
+      {:ok, (for {key, jwt_key} <- jwt_metadata_mapping,
         jwt_val = claims[jwt_key],
         into: %{},
-        do: {key, jwt_val}
+        do: {key, jwt_val})}
     else
       {:error, _} ->
-        %{}
+        {:error, %{}}
     end
   end
 
   # ---
 
-  defp extract_metadata_from_json(conn) do
-    with {"application", "json"} <- content_type(conn),
-         {:ok, body, _conn} <- BodyReader.read_full_body(conn),
-         {:ok, json} <- Jason.decode(body),
+  def extract_metadata_from_json(body) do
+    with {:ok, json} <- Jason.decode(body),
          {:parse, %{"metadata" => metadata}} <- {:parse, json} do
       {:ok, metadata}
     else
@@ -180,9 +190,14 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
 
   # ---
 
+  @doc """
+  Since RIG can propagate metadata through its network of RIG nodes, these datasets **need** to have all of the required indices (as specified in the configuration) for the mapping (index -> RIG instance where the data is actually located at) to work.
+
+  There are no *required* fields in RIG metadata, just required indices. Thus, this method is called `has_required_indices` and not `has_required_fields`.
+  """
   defp has_required_indices?(metadata) do
     conf = config()
-    metadata_keys = Enum.map(metadata, fn x -> x |> elem(0) end)
+    metadata_keys = Map.keys(metadata)
     Enum.all?(conf.indexed_metadata, fn x -> Enum.member?(metadata_keys, x) end)
   end
 

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -3,7 +3,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
   Handles inbound metadata sets and the indexing and distribution of metadata
   """
   use RigInboundGatewayWeb, :controller
-  use Rig.Config, [:indexed_metadata]
+  use Rig.Config, [:jwt_fields, :indexed_metadata]
 
   alias Result
   alias RIG.JWT
@@ -49,11 +49,15 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
   A user connects to RIG 1 and sends the metadata fields from above to RIG 1. RIG 1 would propagate the connection token and the userid along with the RIG instance ID to all other RIG instances.
   If someone were to access the metadata of a user from RIG 3, RIG 3 would know where to find the metadata, ask RIG 1 for it and return the metadata set.
 
-  ## Dirty testing
+  ## Dirty testing with JWT
 
-      AUTH='Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTY4NzEzMzYxLCJleHAiOjQxMDMyNTgxNDN9.mvoW9aM-IiO6J78IMGTnXCUuspxnNe7BVAlKZr89ka4'
-      META='{ "metadata": { "userid": "9ab1bff2-a8d8-455c-b48a-50145d7d8e30", "locale": "de-AT", "timezone": "GMT+2" } }'
+      AUTH='Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5YWIxYmZmMi1hOGQ4LTQ1NWMtYjQ4YS01MDE0NWQ3ZDhlMzAiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1Njg3MTMzNjEsImV4cCI6NDEwMzI1ODE0M30.kjiR7kFyOEeMJaY1zPCctut39eEWmKswUCNZdK5Q3-w'
+      META='{ "metadata": { "locale": "de-AT", "timezone": "GMT+2" } }'
       http put ":4000/_rig/v1/connection/sse/${CONN_TOKEN}/metadata" <<< "$META" "$AUTH"
+
+  ## Dirty testing without JWT
+      META='{ "metadata": { "userid": "9ab1bff2-a8d8-455c-b48a-50145d7d8e30", "locale": "de-AT", "timezone": "GMT+2" } }'
+      http put ":4000/_rig/v1/connection/sse/${CONN_TOKEN}/metadata" <<< "$META"
 
   """
   @spec set_metadata(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -46,29 +46,40 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
 
   ## Example
 
-  A user connects to RIG 1 and sends the metadata fields from above to RIG 1. RIG 1 would propagate the connection token and the userid along with the RIG instance ID to all other RIG instances (via gen_tcp, preferably).
+  A user connects to RIG 1 and sends the metadata fields from above to RIG 1. RIG 1 would propagate the connection token and the userid along with the RIG instance ID to all other RIG instances.
   If someone were to access the metadata of a user from RIG 3, RIG 3 would know where to find the metadata, ask RIG 1 for it and return the metadata set.
 
   """
   @spec set_metadata(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
   def set_metadata(
-      %{method: "PUT"} = conn,
-      %{
-         "connection_id" => connection_id
-      }
-  ) do
+        %{method: "PUT"} = conn,
+        %{
+          "connection_id" => connection_id
+        }
+      ) do
     conn
     |> accept_only_req_for(["application/json"])
     |> decode_metadata()
     |> do_set_metadata(connection_id)
   end
 
-  def decode_metadata(conn) do
+  defp decode_metadata(conn) do
     with {"application", "json"} <- content_type(conn),
          {:ok, body, conn} <- BodyReader.read_full_body(conn),
          {:ok, json} <- Jason.decode(body),
          {:parse, %{"metadata" => metadata}} <- {:parse, json},
          {:idx, true} <- {:idx, contains_idx?(metadata)} do
+
+      conf = config()
+      jwt_fields = conf.jwt_fields
+      
+      jwt_fields 
+      |> Enum.each(fn x ->
+        key = x |> elem(1)
+        metadata = Map.replace!(metadata, key, "!")
+        # TODO: Fix
+        IO.inspect metadata
+      end)
 
       conn
       |> Plug.Conn.assign(:metadata, metadata)
@@ -102,30 +113,31 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
     end
   end
 
-  def do_set_metadata(%{halted: true} = conn, _connection_id), do: conn
-  
-  def do_set_metadata(%{assigns: %{metadata: metadata}} = conn, connection_id) do
-    Logger.info inspect(metadata)
-    
-    conf = config()
-    indexed_fields = Enum.map(conf.indexed_metadata, fn x -> 
-      {x, metadata[x]}
-    end)
+  defp do_set_metadata(%{halted: true} = conn, _connection_id), do: conn
 
-    Logger.info inspect(indexed_fields)
+  defp do_set_metadata(%{assigns: %{metadata: metadata}} = conn, connection_id) do
+    Logger.info(inspect(metadata))
+
+    conf = config()
+
+    indexed_fields =
+      Enum.map(conf.indexed_metadata, fn x ->
+        {x, metadata[x]}
+      end)
+
+    Logger.info(inspect(indexed_fields))
 
     send_resp(conn, :no_content, "")
   end
 
-  def contains_idx?(metadata) do
+  defp contains_idx?(metadata) do
     conf = config()
     metadata_keys = Enum.map(metadata, fn x -> x |> elem(0) end)
     Enum.all?(conf.indexed_metadata, fn x -> Enum.member?(metadata_keys, x) end)
   end
 
-  def fail!(conn, msg) do
+  defp fail!(conn, msg) do
     send_resp(conn, :bad_request, msg)
     Plug.Conn.halt(conn)
   end
-
 end

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -1,4 +1,7 @@
 defmodule RigInboundGatewayWeb.V1.MetadataController do
+  @moduledoc """
+  Handles inbound metadata sets and the indexing and distribution of metadata 
+  """
   use RigInboundGatewayWeb, :controller
 
   alias Result
@@ -14,6 +17,45 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
 
   require Logger
 
+  @doc """
+  Sets metadata KV pairs for an existing connection, replacing previous metadata sets.
+
+  There may be indexed metadata pairs defined. If a metadata set does not contain these indexed keys, it cannot be accepted.
+  
+  ## Example
+
+  Metadata set that contains a user ID, locale and timezone:
+
+      {
+        "metadata": {
+          "userid": "9ab1bff2-a8d8-455c-b48a-50145d7d8e30",
+          "locale": "de-AT",+
+          "timezone": "GMT+1"
+        }
+      }
+
+  In this example, the field "userid" might be indexed. In this case, the connection token would get associated with the value of the "userid" field.
+  In addition to that, the value of the "userid", "locale" and "timezone" fields would get associated to the connection token.
+
+  To sum it up: the connection token is indexed by default, while all other fields can be indexed by configuration.
+
+  So the association would look like so:
+
+      userid -> connection token
+      
+      conection token ->
+        userid
+        locale
+        timezone
+
+  All indexed fields are then being propagated to all other instances so they know where to find the corresponding metadata.
+
+  ## Example
+
+  A user connects to RIG 1 and sends the metadata fields from above to RIG 1. RIG 1 would propagate the connection token and the userid along with the RIG instance ID to all other RIG instances.
+  If someone were to access the metadata of a user from RIG 3, RIG 3 would know where to find the metadata, ask RIG 1 for it and return the metadata set.
+
+  """
   @spec set_metadata(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
   def set_metadata(
       %{method: "PUT"} = conn,

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -1,0 +1,29 @@
+defmodule RigInboundGatewayWeb.V1.MetadataController do
+  use RigInboundGatewayWeb, :controller
+
+  alias Result
+
+  alias RIG.AuthorizationCheck.Request
+  alias RIG.AuthorizationCheck.Subscription, as: SubscriptionAuthZ
+  alias Rig.Connection
+  alias RIG.JWT
+  alias RIG.Plug.BodyReader
+  alias RIG.Session
+  alias Rig.Subscription
+  alias RIG.Subscriptions
+
+  require Logger
+
+  @spec set_metadata( conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
+  def set_metadata(
+      %{method: "PUT"} = conn,
+      %{
+         "connection_id" => connection_id
+      }
+  ) do
+    IO.puts "REACHED SET METADATA"
+    IO.puts(BodyReader.read_full_body(conn) |> elem(1))
+
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -72,14 +72,18 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
 
       conf = config()
       jwt_fields = conf.jwt_fields
-      
-      jwt_fields 
-      |> Enum.each(fn x ->
-        key = x |> elem(1)
-        metadata = Map.replace!(metadata, key, "!")
-        # TODO: Fix
-        IO.inspect metadata
+      jwt_keys = Map.values(jwt_fields)
+
+      metadata = metadata
+      |> Enum.map(fn x ->
+        if Enum.member?(jwt_keys, x |> elem(0)) do
+          # TODO: Replace with value from JWT
+          {x |> elem(0), "!"}
+        else
+          x
+        end
       end)
+      |> Enum.into(%{})
 
       conn
       |> Plug.Conn.assign(:metadata, metadata)

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -34,7 +34,7 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
         }
       }
 
-  In this example, the field "userid" might be indexed. In this case, the connection token would get associated with the value of the "userid" field.
+  In this example, the field "userid" might be indexed. In this case, the connection token would get associated with the value of the "userid" field (it will be possible to automatically take the user id from the JWT token (so that it cannot be changed by any other way) and index that; this will be serverside configuration). 
   In addition to that, the value of the "userid", "locale" and "timezone" fields would get associated to the connection token.
 
   To sum it up: the connection token is indexed by default, while all other fields can be indexed by configuration.

--- a/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/metadata_controller.ex
@@ -63,8 +63,18 @@ defmodule RigInboundGatewayWeb.V1.MetadataController do
          "connection_id" => connection_id
       }
   ) do
-    IO.puts "REACHED SET METADATA"
-    IO.puts(inspect(BodyReader.read_full_body(conn)))
+    # Decode JSON
+    metadata = Jason.decode(
+                  BodyReader.read_full_body(conn)
+                  |> elem(1))
+
+    # Check if there was a decode error
+    case metadata do
+      {:ok, %{"metadata" => data}} ->
+        IO.inspect data
+      {_, %Jason.DecodeError{}} -> 
+        IO.puts "Error!"
+    end
 
     send_resp(conn, :no_content, "")
   end

--- a/test/metadata_controller_test.exs
+++ b/test/metadata_controller_test.exs
@@ -1,0 +1,45 @@
+defmodule RigInboundGatewayWeb.V1.MetadataControllerTest do
+    use ExUnit.Case, async: false
+
+    alias RigInboundGatewayWeb.V1.MetadataController
+
+    describe "Extract metadata:" do
+        test " from JWT" do
+            auth_tokens = [
+                {"bearer", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5YWIxYmZmMi1hOGQ4LTQ1NWMtYjQ4YS01MDE0NWQ3ZDhlMzAiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1Njg3MTMzNjEsImV4cCI6NDEwMzI1ODE0M30.kjiR7kFyOEeMJaY1zPCctut39eEWmKswUCNZdK5Q3-w"}
+            ]
+
+            {:ok, jwt_values} = MetadataController.extract_metadata_from_jwt(auth_tokens)
+            assert jwt_values["userid"] === "9ab1bff2-a8d8-455c-b48a-50145d7d8e30"
+        end
+
+        test " from JSON" do
+            json = "{\"metadata\": { \"locale\": \"de-AT\", \"timezone\": \"GMT+2\" } }"
+            
+            {:ok,json_values} = MetadataController.extract_metadata_from_json(json)
+            assert json_values["locale"] === "de-AT"
+            assert json_values["timezone"] === "GMT+2"
+        end
+    end
+
+    describe "Fail extract metadata:" do
+        test " from JWT" do
+            auth_tokens = [
+                {"bearer", "eyJhbGciOiJIUzI1NiIsInR5cCeMJaY1zPCctut39eEWmKswUCNZdK5Q3-w"}
+            ]
+    
+            {err, jwt_values} = MetadataController.extract_metadata_from_jwt(auth_tokens)
+            assert err === :error
+            assert jwt_values === %{}
+        end
+
+        test " from JSON" do
+            json = "{\"metadata\": { locale\": \"de-AT\", \"timezone\": \"GMT+2\" } }"
+            
+            {err, json_values} = MetadataController.extract_metadata_from_json(json)
+            assert err === :error
+            assert is_binary(json_values) 
+        end
+    end
+
+end  


### PR DESCRIPTION
## Description

This adds the stub for the metadata endpoint for the new Session API. The whole idea here is that the frontend can send metadata to RIG. One can configure indices, use values from the JWT as metadata and set aliases for the JWT values. The RIG instance that receives the metadata from a client will extract data from the JWT, check the metadata set contains all indices and forward all indices to all other RIG instances.

### Example 1 - Simple index

Say, you have your RIG instance configured so you have an index on the field `userid`. This means the config would look like so: 

```elixir
config :rig, RigInboundGatewayWeb.V1.MetadataController,
  jwt_fields: %{},
  indexed_metadata: ["userid"]
```

And you send a metadata JSON that looks like this:

```js
{
    "metadata":
    { 
        "userid": "9ab1bff2-a8d8-455c-b48a-50145d7d8e30",
        "locale": "de-AT",
        "timezone": "GMT+2"
    }
}
```

RIG would distribute `userid` and the connection token to all other RIG instances to tell them where the metadata for these keys are.

### Example 2 - Index on extracted value

One can also extract values from the JWT. Say, we extract the `userid` value from the `sub` field in our JWT with a configuration looking like this:

```elixir
config :rig, RigInboundGatewayWeb.V1.MetadataController,
  jwt_fields: %{"userid" => "sub"},
  indexed_metadata: ["userid"]
```

One could send the following JWT: 

```jwt
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5YWIxYmZmMi1hOGQ4LTQ1NWMtYjQ4YS01MDE0NWQ3ZDhlMzAiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1Njg3MTMzNjEsImV4cCI6NDEwMzI1ODE0M30.kjiR7kFyOEeMJaY1zPCctut39eEWmKswUCNZdK5Q3-w
```

Along with the following JSON:

```js
{
    "metadata":
    { 
        "locale": "de-AT",
        "timezone": "GMT+2"
    }
}
```

## What to look out for

As this is just a WIP PR for code review please:
- check that everything works on your machine.
- test the endpoint (as described under "Dirty testing with JWT" and "Dirty testing without JWT" in lib/rig_inbound_gateway_web/v1/metadata_controller.ex).
- suggest implementation-code design/structure/readability improvements.
- suggest documentation improvements.
- suggest language/writing improvements.
