### PR TITLE
Fix flaky Cypress tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#227](https://github.com/Accenture/reactive-interaction-gateway/issues/227)
 - Refactor JWT related code in favor of `RIG.JWT`.
   [#244](https://github.com/Accenture/reactive-interaction-gateway/pull/244)
+- Fix flaky cypress tests; this shouldn't be an issue anymore when running Travis builds.
 
 ## [2.2.1] - 2019-06-21
 

--- a/examples/tests/cypress/integration/channels.spec.js
+++ b/examples/tests/cypress/integration/channels.spec.js
@@ -6,7 +6,7 @@ describe('Channels', () => {
       cy.subscribe('mike', 'my.public.event');
       // "foo":"bar" due to way how Cypress handles escaping of curly braces
       cy.sendEvent('my.public.event', '"foo":"bar"');
-      cy.assertReceivedEvents('event-log', '(.*my.public.event)(.*"foo":"bar")');
+      cy.assertReceivedEventLog('event-log', '(.*my.public.event)(.*"foo":"bar")');
       cy.disconnect();
     });
 
@@ -16,11 +16,11 @@ describe('Channels', () => {
       cy.subscribe('mike', 'message');
       // "name":"mike","foo":"bar" due to way how Cypress handles escaping of curly braces
       cy.sendEvent('message', '"name":"mike","foo":"bar"');
-      cy.assertReceivedEvents('event-log', 'message', '"name":"mike","foo":"bar"');
+      cy.assertReceivedEventLog('event-log', '"name":"mike","foo":"bar"');
       // send constrained event for different user - John
       cy.sendEvent('message', '"name":"john","foo":"bar"');
       // Mike shouldn't receive any new event
-      cy.wait(2000).assertReceivedEvents(
+      cy.assertReceivedEventLog(
         'event-log',
         '(.*message)(.*"name":"mike","foo":"bar")'
       );

--- a/examples/tests/cypress/integration/channels.spec.js
+++ b/examples/tests/cypress/integration/channels.spec.js
@@ -6,7 +6,7 @@ describe('Channels', () => {
       cy.subscribe('mike', 'my.public.event');
       // "foo":"bar" due to way how Cypress handles escaping of curly braces
       cy.sendEvent('my.public.event', '"foo":"bar"');
-      cy.assertSingleNewEventContainsMessage('event-log', '(.*my.public.event)(.*"foo":"bar")');
+      cy.assertEventLogHasMatch('(.*my.public.event)(.*"foo":"bar")');
       cy.disconnect();
     });
 
@@ -16,14 +16,11 @@ describe('Channels', () => {
       cy.subscribe('mike', 'message');
       // "name":"mike","foo":"bar" due to way how Cypress handles escaping of curly braces
       cy.sendEvent('message', '"name":"mike","foo":"bar"');
-      cy.assertSingleNewEventContainsMessage('event-log', '"name":"mike","foo":"bar"');
+      cy.assertEventLogHasMatch('"name":"mike","foo":"bar"');
       // send constrained event for different user - John
       cy.sendEvent('message', '"name":"john","foo":"bar"');
       // Mike shouldn't receive any new event
-      cy.assertSingleNewEventContainsMessage(
-        'event-log',
-        '(.*message)(.*"name":"mike","foo":"bar")'
-      );
+      cy.assertEventLogHasMatch('(.*message)(.*"name":"mike","foo":"bar")');
       cy.disconnect();
     });
   });

--- a/examples/tests/cypress/integration/channels.spec.js
+++ b/examples/tests/cypress/integration/channels.spec.js
@@ -6,7 +6,7 @@ describe('Channels', () => {
       cy.subscribe('mike', 'my.public.event');
       // "foo":"bar" due to way how Cypress handles escaping of curly braces
       cy.sendEvent('my.public.event', '"foo":"bar"');
-      cy.assertReceivedEventLog('event-log', '(.*my.public.event)(.*"foo":"bar")');
+      cy.assertSingleNewEventContainsMessage('event-log', '(.*my.public.event)(.*"foo":"bar")');
       cy.disconnect();
     });
 
@@ -16,11 +16,11 @@ describe('Channels', () => {
       cy.subscribe('mike', 'message');
       // "name":"mike","foo":"bar" due to way how Cypress handles escaping of curly braces
       cy.sendEvent('message', '"name":"mike","foo":"bar"');
-      cy.assertReceivedEventLog('event-log', '"name":"mike","foo":"bar"');
+      cy.assertSingleNewEventContainsMessage('event-log', '"name":"mike","foo":"bar"');
       // send constrained event for different user - John
       cy.sendEvent('message', '"name":"john","foo":"bar"');
       // Mike shouldn't receive any new event
-      cy.assertReceivedEventLog(
+      cy.assertSingleNewEventContainsMessage(
         'event-log',
         '(.*message)(.*"name":"mike","foo":"bar")'
       );

--- a/examples/tests/cypress/integration/subscriptions-jwt.spec.js
+++ b/examples/tests/cypress/integration/subscriptions-jwt.spec.js
@@ -4,7 +4,7 @@ describe('Subscriptions with JWT auth', () => {
       cy.visit(`/${type}-3-demo-jwt.html`);
       cy.setAndVerifyInput('greeting', 'hello');
       cy.submit();
-      cy.assertReceivedEvents('eventList', 'hello');
+      cy.assertNewestEventContainsMessage('eventList', 'hello');
     });
 
     it(`Applies ${type} subscription constraints tied with JWT for given event type`, () => {
@@ -12,12 +12,12 @@ describe('Subscriptions with JWT auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'john');
       cy.submit();
-      cy.assertReceivedEvents('eventList', '"name":"john","greeting":"hello"');
+      cy.assertNewestEventContainsMessage('eventList', '"name":"john","greeting":"hello"');
       // John shouldn't receive Mike's events
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.assertReceivedEvents('eventList', '"name":"john","greeting":"hello"');
+      cy.assertNewestEventContainsMessage('eventList', '"name":"john","greeting":"hello"');
     });
 
     it(`Creates ${type} subscriptions based on JWT in connection call and applies constraints`, () => {
@@ -25,12 +25,12 @@ describe('Subscriptions with JWT auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'john.doe');
       cy.submit();
-      cy.assertReceivedEvents('eventList', '"name":"john.doe","greeting":"hello"');
+      cy.assertNewestEventContainsMessage('eventList', '"name":"john.doe","greeting":"hello"');
       // John Doe shouldn't receive Mike's events
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.assertReceivedEvents(
+      cy.assertNewestEventContainsMessage(
         'eventList',
         '"name":"john.doe","greeting":"hello"'
       );

--- a/examples/tests/cypress/integration/subscriptions-jwt.spec.js
+++ b/examples/tests/cypress/integration/subscriptions-jwt.spec.js
@@ -17,7 +17,7 @@ describe('Subscriptions with JWT auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.wait(2000).assertReceivedEvents('eventList', '"name":"john","greeting":"hello"');
+      cy.assertReceivedEvents('eventList', '"name":"john","greeting":"hello"');
     });
 
     it(`Creates ${type} subscriptions based on JWT in connection call and applies constraints`, () => {
@@ -30,7 +30,7 @@ describe('Subscriptions with JWT auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.wait(2000).assertReceivedEvents(
+      cy.assertReceivedEvents(
         'eventList',
         '"name":"john.doe","greeting":"hello"'
       );

--- a/examples/tests/cypress/integration/subscriptions-jwt.spec.js
+++ b/examples/tests/cypress/integration/subscriptions-jwt.spec.js
@@ -4,7 +4,7 @@ describe('Subscriptions with JWT auth', () => {
       cy.visit(`/${type}-3-demo-jwt.html`);
       cy.setAndVerifyInput('greeting', 'hello');
       cy.submit();
-      cy.assertNewestEventContainsMessage('eventList', 'hello');
+      cy.assertNewestEventInEventList('hello');
     });
 
     it(`Applies ${type} subscription constraints tied with JWT for given event type`, () => {
@@ -12,12 +12,12 @@ describe('Subscriptions with JWT auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'john');
       cy.submit();
-      cy.assertNewestEventContainsMessage('eventList', '"name":"john","greeting":"hello"');
+      cy.assertNewestEventInEventList('"name":"john","greeting":"hello"');
       // John shouldn't receive Mike's events
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.assertNewestEventContainsMessage('eventList', '"name":"john","greeting":"hello"');
+      cy.assertNewestEventInEventList('"name":"john","greeting":"hello"');
     });
 
     it(`Creates ${type} subscriptions based on JWT in connection call and applies constraints`, () => {
@@ -25,15 +25,12 @@ describe('Subscriptions with JWT auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'john.doe');
       cy.submit();
-      cy.assertNewestEventContainsMessage('eventList', '"name":"john.doe","greeting":"hello"');
+      cy.assertNewestEventInEventList('"name":"john.doe","greeting":"hello"');
       // John Doe shouldn't receive Mike's events
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.assertNewestEventContainsMessage(
-        'eventList',
-        '"name":"john.doe","greeting":"hello"'
-      );
+      cy.assertNewestEventInEventList('"name":"john.doe","greeting":"hello"');
     });
   });
 });

--- a/examples/tests/cypress/integration/subscriptions-no-auth.spec.js
+++ b/examples/tests/cypress/integration/subscriptions-no-auth.spec.js
@@ -4,14 +4,14 @@ describe('Subscriptions with no auth', () => {
       cy.visit(`/${type}-1-demo.html`);
       cy.setAndVerifyInput('greeting', 'hello');
       cy.submit();
-      cy.assertReceivedEvents('eventList', 'hello');
+      cy.assertNewestEventContainsMessage('eventList', 'hello');
     });
 
     it(`Creates ${type} connection and subscriptions within a same call`, () => {
       cy.visit(`/${type}-demo-single-call.html`);
       cy.setAndVerifyInput('greeting', 'hello');
       cy.submit();
-      cy.assertReceivedEvents('eventList', 'hello');
+      cy.assertNewestEventContainsMessage('eventList', 'hello');
     });
 
     it(`Applies ${type} subscription constraints for given event type`, () => {
@@ -19,12 +19,12 @@ describe('Subscriptions with no auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'john');
       cy.submit();
-      cy.assertReceivedEvents('eventList', '"name":"john","greeting":"hello"');
+      cy.assertNewestEventContainsMessage('eventList', '"name":"john","greeting":"hello"');
       // John shouldn't receive Mike's events
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.assertReceivedEvents('eventList', '"name":"john","greeting":"hello"');
+      cy.assertNewestEventContainsMessage('eventList', '"name":"john","greeting":"hello"');
     });
   });
 });

--- a/examples/tests/cypress/integration/subscriptions-no-auth.spec.js
+++ b/examples/tests/cypress/integration/subscriptions-no-auth.spec.js
@@ -4,14 +4,14 @@ describe('Subscriptions with no auth', () => {
       cy.visit(`/${type}-1-demo.html`);
       cy.setAndVerifyInput('greeting', 'hello');
       cy.submit();
-      cy.assertNewestEventContainsMessage('eventList', 'hello');
+      cy.assertNewestEventInEventList('hello');
     });
 
     it(`Creates ${type} connection and subscriptions within a same call`, () => {
       cy.visit(`/${type}-demo-single-call.html`);
       cy.setAndVerifyInput('greeting', 'hello');
       cy.submit();
-      cy.assertNewestEventContainsMessage('eventList', 'hello');
+      cy.assertNewestEventInEventList('hello');
     });
 
     it(`Applies ${type} subscription constraints for given event type`, () => {
@@ -19,12 +19,12 @@ describe('Subscriptions with no auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'john');
       cy.submit();
-      cy.assertNewestEventContainsMessage('eventList', '"name":"john","greeting":"hello"');
+      cy.assertNewestEventInEventList('"name":"john","greeting":"hello"');
       // John shouldn't receive Mike's events
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.assertNewestEventContainsMessage('eventList', '"name":"john","greeting":"hello"');
+      cy.assertNewestEventInEventList('"name":"john","greeting":"hello"');
     });
   });
 });

--- a/examples/tests/cypress/integration/subscriptions-no-auth.spec.js
+++ b/examples/tests/cypress/integration/subscriptions-no-auth.spec.js
@@ -24,7 +24,7 @@ describe('Subscriptions with no auth', () => {
       cy.setAndVerifyInput('greeting', 'hello');
       cy.setAndVerifyInput('name', 'mike');
       cy.submit();
-      cy.wait(2000).assertReceivedEvents('eventList', '"name":"john","greeting":"hello"');
+      cy.assertReceivedEvents('eventList', '"name":"john","greeting":"hello"');
     });
   });
 });

--- a/examples/tests/cypress/support/commands.js
+++ b/examples/tests/cypress/support/commands.js
@@ -48,7 +48,15 @@ Cypress.Commands.add('sendEvent', (eventType, message) => {
 
 Cypress.Commands.add('assertReceivedEvents', (element, message) => {
   // assert number and content of received events
-  cy.get(`#${element}`)
+  cy.get(`#${element} > li`, {timeout: 30000})
+    .should('be.visible')
+    .first()
+    .contains(message)
+});
+
+Cypress.Commands.add('assertReceivedEventLog', (element, message) => {
+  // assert number and content of received events
+  cy.get(`#${element}`, {timeout: 30000})
     .should('have.length', 1)
     .first()
     .contains(new RegExp(message, 'g'));

--- a/examples/tests/cypress/support/commands.js
+++ b/examples/tests/cypress/support/commands.js
@@ -46,17 +46,17 @@ Cypress.Commands.add('sendEvent', (eventType, message) => {
   cy.get('#send-button').click();
 });
 
-Cypress.Commands.add('assertNewestEventContainsMessage', (element, message) => {
+Cypress.Commands.add('assertNewestEventInEventList', (message) => {
   // assert number and content of received events
-  cy.get(`#${element} > li`, {timeout: 30000})
+  cy.get(`#eventList > li`, {timeout: 30000})
     .should('be.visible')
     .first()
     .contains(message)
 });
 
-Cypress.Commands.add('assertSingleNewEventContainsMessage', (element, message) => {
+Cypress.Commands.add('assertEventLogHasMatch', (message) => {
   // assert number and content of received events
-  cy.get(`#${element}`, {timeout: 30000})
+  cy.get(`#event-log`, {timeout: 30000})
     .should('have.length', 1)
     .first()
     .contains(new RegExp(message, 'g'));

--- a/examples/tests/cypress/support/commands.js
+++ b/examples/tests/cypress/support/commands.js
@@ -46,7 +46,7 @@ Cypress.Commands.add('sendEvent', (eventType, message) => {
   cy.get('#send-button').click();
 });
 
-Cypress.Commands.add('assertReceivedEvents', (element, message) => {
+Cypress.Commands.add('assertNewestEventContainsMessage', (element, message) => {
   // assert number and content of received events
   cy.get(`#${element} > li`, {timeout: 30000})
     .should('be.visible')
@@ -54,7 +54,7 @@ Cypress.Commands.add('assertReceivedEvents', (element, message) => {
     .contains(message)
 });
 
-Cypress.Commands.add('assertReceivedEventLog', (element, message) => {
+Cypress.Commands.add('assertSingleNewEventContainsMessage', (element, message) => {
   // assert number and content of received events
   cy.get(`#${element}`, {timeout: 30000})
     .should('have.length', 1)


### PR DESCRIPTION
## Description

There were some timing problems with Cypress while running in CI which didn't occur while running locally (probably due to the CI instance being slower than our local machines). I fixed this by using the built-in Cypress timeouts. 