### PR TITLE
272 - Fix HTTP response for API delete endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed usage of external check for `SUBMISSION_CHECK` and `SUBSCRIPTION_CHECK`. [#241](https://github.com/Accenture/reactive-interaction-gateway/issues/241)
 - Logging incoming HTTP request to Kafka works again and now also supports Apache Avro.
   [#170](https://github.com/Accenture/reactive-interaction-gateway/issues/170)
+- Fixed HTTP response for `DELETE 4010/v1/apis/api_id` and `DELETE 4010/v2/apis/api_id` to correctly return `204` and no content.
 
 <!-- ### Deprecated -->
 

--- a/lib/rig_api/v1/apis.ex
+++ b/lib/rig_api/v1/apis.ex
@@ -20,6 +20,8 @@ defmodule RigApi.V1.APIs do
     send_response(conn, 200, active_apis)
   end
 
+  # ---
+
   swagger_path :get_api_detail do
     get(@prefix <> "/apis/{apiId}")
     summary("Obtain details on a proxy API-definition.")
@@ -43,6 +45,8 @@ defmodule RigApi.V1.APIs do
         send_response(conn, 200, api)
     end
   end
+
+  # ---
 
   swagger_path :add_api do
     post(@prefix <> "/apis")
@@ -78,6 +82,8 @@ defmodule RigApi.V1.APIs do
     end
   end
 
+  # ---
+
   swagger_path :update_api do
     put(@prefix <> "/apis/{apiId}")
     summary("Update a proxy API-definition.")
@@ -109,6 +115,8 @@ defmodule RigApi.V1.APIs do
     end
   end
 
+  # ---
+
   swagger_path :deactivate_api do
     delete(@prefix <> "/apis/{apiId}")
     summary("Deactivate a proxy API-definition.")
@@ -117,7 +125,7 @@ defmodule RigApi.V1.APIs do
       apiId(:path, :string, "API definition identifier", required: true, example: "new-service")
     end
 
-    response(204, "Deleted")
+    response(204, "")
     response(404, "Doesn't exist", Schema.ref(:ProxyAPIResponse))
   end
 
@@ -127,12 +135,14 @@ defmodule RigApi.V1.APIs do
 
     with {_id, _current_api} <- get_active_api(id),
          {:ok, _phx_ref} <- proxy.deactivate_api(proxy, id) do
-      send_response(conn, 204)
+      send_response(conn, :no_content)
     else
       api when api == nil or api == :inactive ->
         send_response(conn, 404, %{message: "API with id=#{id} doesn't exists."})
     end
   end
+
+  # ---
 
   defp get_active_api(id) do
     %{rig_proxy: proxy} = config()
@@ -147,10 +157,20 @@ defmodule RigApi.V1.APIs do
     end
   end
 
+  # ---
+
   defp merge_and_update(id, current_api, updated_api) do
     %{rig_proxy: proxy} = config()
     merged_api = current_api |> Map.merge(updated_api)
     proxy.update_api(proxy, id, merged_api)
+  end
+
+  # ---
+
+  defp send_response(conn, :no_content) do
+    conn
+    |> put_status(:no_content)
+    |> text("")
   end
 
   defp send_response(conn, status_code, body \\ %{}) do
@@ -158,6 +178,8 @@ defmodule RigApi.V1.APIs do
     |> put_status(status_code)
     |> json(body)
   end
+
+  # ---
 
   def swagger_definitions do
     %{

--- a/lib/rig_api/v1/apis_test.exs
+++ b/lib/rig_api/v1/apis_test.exs
@@ -76,8 +76,8 @@ defmodule RigApi.V1.APIsTest do
   describe "DELETE /v1/apis/:id" do
     test "should delete requested API" do
       conn = build_conn() |> delete("/v1/apis/new-service")
-      response = json_response(conn, 204)
-      assert response == %{}
+      response = text_response(conn, :no_content)
+      assert response == ""
     end
 
     test "should return 404 if requested API doesn't exist" do

--- a/lib/rig_api/v2/apis.ex
+++ b/lib/rig_api/v2/apis.ex
@@ -20,6 +20,8 @@ defmodule RigApi.V2.APIs do
     send_response(conn, 200, active_apis)
   end
 
+  # ---
+
   swagger_path :get_api_detail do
     get(@prefix <> "/apis/{apiId}")
     summary("Obtain details on a proxy API-definition.")
@@ -43,6 +45,8 @@ defmodule RigApi.V2.APIs do
         send_response(conn, 200, api)
     end
   end
+
+  # ---
 
   swagger_path :add_api do
     post(@prefix <> "/apis")
@@ -78,6 +82,8 @@ defmodule RigApi.V2.APIs do
     end
   end
 
+  # ---
+
   swagger_path :update_api do
     put(@prefix <> "/apis/{apiId}")
     summary("Update a proxy API-definition.")
@@ -109,6 +115,8 @@ defmodule RigApi.V2.APIs do
     end
   end
 
+  # ---
+
   swagger_path :deactivate_api do
     delete(@prefix <> "/apis/{apiId}")
     summary("Deactivate a proxy API-definition.")
@@ -117,7 +125,7 @@ defmodule RigApi.V2.APIs do
       apiId(:path, :string, "API definition identifier", required: true, example: "new-service")
     end
 
-    response(204, "Deleted")
+    response(204, "")
     response(404, "Doesn't exist", Schema.ref(:ProxyAPIResponse))
   end
 
@@ -127,12 +135,14 @@ defmodule RigApi.V2.APIs do
 
     with {_id, _current_api} <- get_active_api(id),
          {:ok, _phx_ref} <- proxy.deactivate_api(proxy, id) do
-      send_response(conn, 204)
+      send_response(conn, :no_content)
     else
       api when api == nil or api == :inactive ->
         send_response(conn, 404, %{message: "API with id=#{id} doesn't exists."})
     end
   end
+
+  # ---
 
   defp get_active_api(id) do
     %{rig_proxy: proxy} = config()
@@ -147,10 +157,20 @@ defmodule RigApi.V2.APIs do
     end
   end
 
+  # ---
+
   defp merge_and_update(id, current_api, updated_api) do
     %{rig_proxy: proxy} = config()
     merged_api = current_api |> Map.merge(updated_api)
     proxy.update_api(proxy, id, merged_api)
+  end
+
+  # ---
+
+  defp send_response(conn, :no_content) do
+    conn
+    |> put_status(:no_content)
+    |> text("")
   end
 
   defp send_response(conn, status_code, body \\ %{}) do
@@ -158,6 +178,8 @@ defmodule RigApi.V2.APIs do
     |> put_status(status_code)
     |> json(body)
   end
+
+  # ---
 
   def swagger_definitions do
     %{

--- a/lib/rig_api/v2/apis_test.exs
+++ b/lib/rig_api/v2/apis_test.exs
@@ -76,8 +76,8 @@ defmodule RigApi.V2.APIsTest do
   describe "DELETE /v2/apis/:id" do
     test "should delete requested API" do
       conn = build_conn() |> delete("/v2/apis/new-service")
-      response = json_response(conn, 204)
-      assert response == %{}
+      response = text_response(conn, :no_content)
+      assert response == ""
     end
 
     test "should return 404 if requested API doesn't exist" do


### PR DESCRIPTION
## Description

Fixed HTTP response for `DELETE 4010/v1/apis/api_id` and `DELETE 4010/v2/apis/api_id` to correctly return `204` and no content.

Closes #272 

## What to look out for

- you can try the setup from here https://accenture.github.io/reactive-interaction-gateway/docs/api-gateway.html
- call Delete API (both versions) via postman/curl/swagger - API should be correctly deactivated and you should get `204` empty response
