### PR TITLE
WIP: 154 Add VConnection & last_event_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added possibility to define Kafka/Kinesis topic and schema per reverse proxy endpoint. The current solution using environment variables is deprecated, but still used as a fallback -- will be removed in the version 3.0. [#229](https://github.com/Accenture/reactive-interaction-gateway/issues/229)
 - Added Kinesis + Localstack example [#229](https://github.com/Accenture/reactive-interaction-gateway/issues/229)
+- Added abstraction over SSE and WS. This abstraction keeps track of state, manages timers, can be initialized before a client connects to RIG and can be used for reconnects (client can pick up where they left of). This means that for SSE and WS connections, the connection token now refers to this connection abstraction.
+  - With `GET :4000/_rig/v1/connection/init`, one can now pre-initialize this connection
+  - `DELETE :4000/_rig/v1/connection/<connection_pid>` gracefully destroys this abstraction. This is recommended! 
+  - `DELETE :4010/v2/connection/<connection_pid>/socket` destroys the actual (WS/SSE) connection. This is not a public API and should only be used for debug purposes.
+  - Added new configuration option via `IDLE_CONNECTION_TIMEOUT_MS` environment variable. This determines when the connection abstraction should die after the actual socket has disconnected/closed. Default: 300000
+  - RIG now implements a `last_event_id`. This feature can be utilized when reconnecting after the connection to RIG has been lost. All events which were received (and buffered) in the meantime, by the previously mentioned connection abstraction, will be resent.
+  - Added new configuration option via `CONNECTION_BUFFER_SIZE` which determines how many messages this connection abstraction can store while a client is disconnected. Default: 50
+  - Added new configuration option via `RESEND_INTERVAL_MS` which determines the interval in which unreceived messages will be resent when the client reconnects to RIG. Default: 500
 
 <!-- ### Changed -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,42 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added longpolling as new connection type [#217](https://github.com/Accenture/reactive-interaction-gateway/issues/217)
-- When terminating an SSE connection after its associated session has been blacklisted, RIG now sends out a `rig.session_killed` event before closing the socket. For WebSocket connections, the closing frame contains "Session killed." as its payload.
-- New API for querying and updating the session blacklist: `/v2/session-blacklist`, which introduces the following breaking changes:
-  - When a session has been added to the session blacklist successfully, the endpoint now uses the correct HTTP status code "201 Created" instead of "200 Ok".
-  - When using the API to blacklist a session, the `validityInSeconds` should now be passed as an integer value (using a string still works though).
-- Added abstraction over SSE and WS. This abstraction keeps track of state, manages timers, can be initialized before a client connects to RIG and can be used for reconnects (client can pick up where they left of). This means that for SSE and WS connections, the connection token now refers to this connection abstraction.
-  - With `GET /v1/connection/init`, one can now pre-initialize this connection
-  - `DELETE /v1/connection/<connection_pid>` gracefully destroys this abstraction. This is recommended! 
-  - `DELETE /v1/connection/<connection_pid>/socket` destroys the actual (WS/SSE) connection
-  - Added new configuration option via `IDLE_CONNECTION_TIMEOUT` environment variable. This determines when the connection abstraction should die after the actual socket has disconnected/closed.
+- Added possibility to define Kafka/Kinesis topic and schema per reverse proxy endpoint. The current solution using environment variables is deprecated, but still used as a fallback -- will be removed in the version 3.0. [#229](https://github.com/Accenture/reactive-interaction-gateway/issues/229)
+- Added Kinesis + Localstack example [#229](https://github.com/Accenture/reactive-interaction-gateway/issues/229)
 
 <!-- ### Changed -->
 
-### Fixed
-
-- Fixed usage of external check for `SUBMISSION_CHECK` and `SUBSCRIPTION_CHECK`. [#241](https://github.com/Accenture/reactive-interaction-gateway/issues/241)
-- Logging incoming HTTP request to Kafka works again and now also supports Apache Avro.
-  [#170](https://github.com/Accenture/reactive-interaction-gateway/issues/170)
+<!-- ### Fixed -->
 
 <!-- ### Deprecated -->
+
+<!-- ### Removed -->
+
+<!-- ### Security -->
+
+<!-- ### Technical Improvements -->
+
+## [2.3.0] - 2019-12-13
+
+### Added
+
+- In addition to SSE and WebSocket, RIG now also supports HTTP long-polling for listening to events. Frontends should only use this as a fallback in situations where neither SSE nor WebSocket is supported by the network.
+  [#217](https://github.com/Accenture/reactive-interaction-gateway/issues/217)
+- When terminating an SSE connection after its associated session has been blacklisted, RIG now sends out a `rig.session_killed` event before closing the socket. For WebSocket connections, the closing frame contains "Session killed." as its payload.
+  [#261](https://github.com/Accenture/reactive-interaction-gateway/pull/261)
+- New API for querying and updating the session blacklist: `/v2/session-blacklist`, which introduces the following breaking changes (`/v1/session-blacklist` is unaffected) [#261](https://github.com/Accenture/reactive-interaction-gateway/pull/261):
+  - When a session has been added to the session blacklist successfully, the endpoint now uses the correct HTTP status code "201 Created" instead of "200 Ok".
+  - When using the API to blacklist a session, the `validityInSeconds` should now be passed as an integer value (using a string still works though).
+
+### Fixed
+
+- Fixed usage of external check for `SUBMISSION_CHECK` and `SUBSCRIPTION_CHECK`.
+  [#241](https://github.com/Accenture/reactive-interaction-gateway/issues/241)
+- Logging incoming HTTP request to Kafka works again and now also supports Apache Avro.
+  [#170](https://github.com/Accenture/reactive-interaction-gateway/issues/170)
+- Fixed HTTP response for `DELETE 4010/v1/apis/api_id` and `DELETE 4010/v2/apis/api_id` to correctly return `204` and no content.
 
 ### Removed
 
 - Removed the `JWT_BLACKLIST_DEFAULT_EXPIRY_HOURS` environment variable ([deprecated since 2.0.0-beta.2](https://github.com/Accenture/reactive-interaction-gateway/commit/f974533455aa3ebc550ee95bf291585925a406d5)).
+  [#260](https://github.com/Accenture/reactive-interaction-gateway/pull/260)
 
 ### Security
 
 - A connection is now associated to its session right after the connection is established, given the request carries a JWT in its authorization header. Previously, this was only done by the subscriptions endpoint, which could cause a connection to remain active even after blacklisting its authorization token.
+  [#260](https://github.com/Accenture/reactive-interaction-gateway/pull/260)
 
 ### Technical Improvements
 
 - Upgrade the Elixir and Erlang versions for source code and Docker images.
+  [#211](https://github.com/Accenture/reactive-interaction-gateway/issues/211)
 - Automated UI-tests using Cypress make sure that all examples work and that code changes do not introduce any unintended API changes.
   [#227](https://github.com/Accenture/reactive-interaction-gateway/issues/227)
 - Refactor JWT related code in favor of `RIG.JWT`.
   [#244](https://github.com/Accenture/reactive-interaction-gateway/pull/244)
+- Fix flaky cypress tests; this shouldn't be an issue anymore when running Travis builds.
+  [#265](https://github.com/Accenture/reactive-interaction-gateway/pull/265)
 
 ## [2.2.1] - 2019-06-21
 
@@ -239,7 +258,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Flaky tests in `router_test.exs` -- switching from `Bypass` to `Fakeserver`.
   [#74](https://github.com/Accenture/reactive-interaction-gateway/issues/74)
-- Channels example. [#64]https://github.com/Accenture/reactive-interaction-gateway/issues/64
+- Channels example. [#64](https://github.com/Accenture/reactive-interaction-gateway/issues/64)
 
 ## [2.0.0-beta.1] - 2018-06-21
 
@@ -350,7 +369,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable Origin checking.
   [#12](https://github.com/Accenture/reactive-interaction-gateway/pull/12)
 
-[unreleased]: https://github.com/Accenture/reactive-interaction-gateway/compare/2.2.1...HEAD
+[unreleased]: https://github.com/Accenture/reactive-interaction-gateway/compare/2.3.0...HEAD
+[2.3.0]: https://github.com/Accenture/reactive-interaction-gateway/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/Accenture/reactive-interaction-gateway/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/Accenture/reactive-interaction-gateway/compare/2.1.1...2.2.0
 [2.1.1]: https://github.com/Accenture/reactive-interaction-gateway/compare/2.1.0...2.1.1

--- a/config/config.exs
+++ b/config/config.exs
@@ -67,7 +67,9 @@ config :rig, Rig.Connection.Codec,
   codec_default_key: "7tsf4Y6GTOfPY1iDo4PqZA=="
 
 config :rig, RigInboundGatewayWeb.VConnection,
-  idle_connection_timeout: {:system, "IDLE_CONNECTION_TIMEOUT", "300000"}
+  idle_connection_timeout: {:system, "IDLE_CONNECTION_TIMEOUT_MS", "300000"},
+  connection_buffer_size: {:system, "CONNECTION_BUFFER_SIZE", "50"},
+  resend_interval: {:system, "RESEND_INTERVAL_MS", "500"}
 
 config :porcelain, driver: Porcelain.Driver.Basic
 

--- a/config/rig_api/config.exs
+++ b/config/rig_api/config.exs
@@ -46,6 +46,10 @@ config :phoenix, :serve_endpoints, true
 config :rig, RigApi.V1.APIs, rig_proxy: RigInboundGateway.Proxy
 config :rig, RigApi.V2.APIs, rig_proxy: RigInboundGateway.Proxy
 
+cors = {:system, "CORS", "*"}
+
+config :rig, RigApi.V2.ConnectionController, cors: cors
+
 config :rig, :event_filter, Rig.EventFilter
 
 config :rig, :phoenix_swagger,

--- a/docs/rig-ops-guide.md
+++ b/docs/rig-ops-guide.md
@@ -29,7 +29,9 @@ Variable&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 `FIREHOSE_KINESIS_HTTP_TARGETS` | List of HTTP endpoints where events will be sent from `FIREHOSE_KINESIS_STREAM | ["http://localhost:4040/todo"]
 `FIREHOSE_KINESIS_STREAM` | Kinesis stream RIG will use as a firehose consumer. Events will be sent to `FIREHOSE_KINESIS_HTTP_TARGETS | "RIG-firehose"
 `HOST` | Hostname for Phoenix endpoints (HTTP communication). | "localhost"
-`IDLE_CONNECTION_TIMEOUT` | Timeout used to determine when the connection abstraction should die (thus be unable to accept reconnects) after the actual socket has disconnected. | 300000
+`IDLE_CONNECTION_TIMEOUT_MS` | Timeout used to determine when the connection abstraction should die (thus be unable to accept reconnects) after the actual socket has disconnected. | 300000
+`CONNECTION_BUFFER_SIZE` | Determines how many messages the connection abstraction can store while a client is disconnected. | 50 
+`RESEND_INTERVAL_MS` | Determines the interval in which unreceived messages will be resent by the connection abstraction when the client reconnects to RIG. | 500 
 `JWT_SECRET_KEY` | The secret key used to sign and verify the JSON web tokens. | ""
 `JWT_ALG` | Algorithm used to sign and verify JSON web tokens. | "HS256"
 `JWT_SESSION_FIELD` | The JWT claim that defines a "session", which is used for listing and killing/blacklisting sessions. The default is to use a JWT's `jti` claim, which ["provides a unique identifier for the JWT"](https://tools.ietf.org/html/rfc7519#section-4.1.7). This way, when blacklisting a session, the user cannot use the respective token anymore, but is able to create a new one by re-authenticating with the backend. The `JWT_SESSION_FIELD` is specified using the [JSON Pointer](https://tools.ietf.org/html/rfc6901) notation. For example, this is how you would use a custom `sessionId` claim instead of the `jti`: `JWT_SESSION_FIELD=/sessionId`. | "/jti"

--- a/examples/sse-4-demo-connection-init.html
+++ b/examples/sse-4-demo-connection-init.html
@@ -95,12 +95,14 @@
         })
     }
 
+    const apiBaseUrl = "http://localhost:4010/v2";
+
     function disconnect() {
-      fetch(`${baseUrl}/connection/${connectionToken}/`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
+      fetch(`${apiBaseUrl}/connection/${connectionToken}/`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
     }
 
     function disconnect_connection() {
-      fetch(`${baseUrl}/connection/${connectionToken}/socket`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
+      fetch(`${apiBaseUrl}/connection/${connectionToken}/socket`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
     }
 
     var source;

--- a/examples/sse-4-demo-connection-init.html
+++ b/examples/sse-4-demo-connection-init.html
@@ -98,7 +98,7 @@
     const apiBaseUrl = "http://localhost:4010/v2";
 
     function disconnect() {
-      fetch(`${apiBaseUrl}/connection/${connectionToken}/`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
+      fetch(`${baseUrl}/connection/${connectionToken}/`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
     }
 
     function disconnect_connection() {

--- a/examples/ws-4-demo-connection-init.html
+++ b/examples/ws-4-demo-connection-init.html
@@ -97,12 +97,14 @@
         })
     }
 
+    const apiBaseUrl = "http://localhost:4010/v2";
+
     function disconnect() {
-      fetch(`${baseUrl}/connection/${connectionToken}/`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
+      fetch(`${apiBaseUrl}/connection/${connectionToken}/`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
     }
 
     function disconnect_connection() {
-      fetch(`${baseUrl}/connection/${connectionToken}/socket`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
+      fetch(`${apiBaseUrl}/connection/${connectionToken}/socket`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
     }
 
     var source;

--- a/examples/ws-4-demo-connection-init.html
+++ b/examples/ws-4-demo-connection-init.html
@@ -100,7 +100,7 @@
     const apiBaseUrl = "http://localhost:4010/v2";
 
     function disconnect() {
-      fetch(`${apiBaseUrl}/connection/${connectionToken}/`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
+      fetch(`${baseUrl}/connection/${connectionToken}/`, {method: "DELETE", mode: "cors"}).then(msg => { return msg.text() })
     }
 
     function disconnect_connection() {

--- a/lib/rig_api/router.ex
+++ b/lib/rig_api/router.ex
@@ -76,9 +76,6 @@ defmodule RigApi.Router do
 
     scope "/connection" do
       scope "/:connection_id" do
-        delete("/", ConnectionController, :destroy)
-        options("/", ConnectionController, :handle_preflight)
-
         delete("/socket", ConnectionController, :destroy_connection)
         options("/socket", ConnectionController, :handle_preflight)
       end

--- a/lib/rig_api/router.ex
+++ b/lib/rig_api/router.ex
@@ -73,6 +73,16 @@ defmodule RigApi.Router do
       post("/", SessionBlacklist, :blacklist_session)
       get("/:session_id", SessionBlacklist, :check_status)
     end
+
+    scope "/connection" do
+      scope "/:connection_id" do
+        delete("/", ConnectionController, :destroy)
+        options("/", ConnectionController, :handle_preflight)
+
+        delete("/socket", ConnectionController, :destroy_connection)
+        options("/socket", ConnectionController, :handle_preflight)
+      end
+    end
   end
 
   def swagger_info do

--- a/lib/rig_api/v2/connection_controller.ex
+++ b/lib/rig_api/v2/connection_controller.ex
@@ -1,0 +1,55 @@
+defmodule RigApi.V2.ConnectionController do
+  @moduledoc """
+  Exposes functionality to close individual connections.
+  Used in debugging.
+  """
+
+  use Rig.Config, [:cors]
+  use RigInboundGatewayWeb, :controller
+  use RigInboundGatewayWeb.Cors, [:delete]
+
+  alias Rig.Connection.Codec
+
+  # TODO: Evaluate if `destroy` can become a public API.
+  @doc """
+  ### Dirty Testing
+
+      CONN_TOKEN=$(http :4000/_rig/v1/connection/init)
+      http delete ":4010/v2/connection/$CONN_TOKEN/"
+  """
+  @spec destroy(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
+  def destroy(
+        %{method: "DELETE"} = conn,
+        %{
+          "connection_id" => connection_id
+        }
+      ) do
+    {:ok, pid} = Codec.deserialize(connection_id)
+    Process.exit(pid, :kill)
+
+    conn
+    |> with_allow_origin
+    |> send_resp(:ok, "")
+  end
+
+  @doc """
+  ### Dirty Testing
+
+      CONN_TOKEN=$(http :4000/_rig/v1/connection/init)
+      http delete ":4010/v2/connection/$CONN_TOKEN/socket"
+  """
+  @spec destroy_connection(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
+  def destroy_connection(
+        %{method: "DELETE"} = conn,
+        %{
+          "connection_id" => connection_id
+        }
+      ) do
+    {:ok, pid} = Codec.deserialize(connection_id)
+    send(pid, :kill_connection)
+
+    conn
+    |> with_allow_origin
+    |> send_resp(:ok, "")
+  end
+end

--- a/lib/rig_api/v2/connection_controller.ex
+++ b/lib/rig_api/v2/connection_controller.ex
@@ -10,28 +10,6 @@ defmodule RigApi.V2.ConnectionController do
 
   alias Rig.Connection.Codec
 
-  # TODO: Evaluate if `destroy` can become a public API.
-  @doc """
-  ### Dirty Testing
-
-      CONN_TOKEN=$(http :4000/_rig/v1/connection/init)
-      http delete ":4010/v2/connection/$CONN_TOKEN/"
-  """
-  @spec destroy(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
-  def destroy(
-        %{method: "DELETE"} = conn,
-        %{
-          "connection_id" => connection_id
-        }
-      ) do
-    {:ok, pid} = Codec.deserialize(connection_id)
-    Process.exit(pid, :kill)
-
-    conn
-    |> with_allow_origin
-    |> send_resp(:ok, "")
-  end
-
   @doc """
   ### Dirty Testing
 

--- a/lib/rig_inbound_gateway_web/connection_init.ex
+++ b/lib/rig_inbound_gateway_web/connection_init.ex
@@ -76,6 +76,11 @@ defmodule RigInboundGatewayWeb.ConnectionInit do
                 send(pid, :set_subscriptions)
               end
 
+              if request.last_event_id != nil do
+                IO.puts "Last event id received!"
+                send pid, {:schedule_missing, request.last_event_id}
+              end
+
               vpid
             else
               # If the reconnect failed, proceed as usual

--- a/lib/rig_inbound_gateway_web/event_buffer.ex
+++ b/lib/rig_inbound_gateway_web/event_buffer.ex
@@ -42,7 +42,7 @@ defmodule RigInboundGatewayWeb.EventBuffer do
   @spec events_since(__MODULE__.t(), event_id :: String.t()) ::
           {:ok, [events: [CloudEvent.t()], last_event_id: String.t()]}
           | {:no_such_event, [not_found_id: String.t(), last_event_id: String.t()]}
-  def events_since(%{capacity: capacity, events: events}, event_id) do
+  def events_since(%{capacity: capacity, events: events}, event_id) when events != [] do
     last_event_id = events |> hd() |> CloudEvent.id!()
     newer_events = Enum.take_while(events, fn event -> CloudEvent.id!(event) != event_id end)
 
@@ -52,5 +52,9 @@ defmodule RigInboundGatewayWeb.EventBuffer do
       newer_events_asc = Enum.reverse(newer_events)
       {:ok, [events: newer_events_asc, last_event_id: last_event_id]}
     end
+  end
+
+  def events_since(_, _) do
+    {:ok, [events: []]}
   end
 end

--- a/lib/rig_inbound_gateway_web/router.ex
+++ b/lib/rig_inbound_gateway_web/router.ex
@@ -15,6 +15,9 @@ defmodule RigInboundGatewayWeb.Router do
       scope "/connection" do
         get("/init", ConnectionController, :init)
 
+        delete("/:connection_id", ConnectionController, :destroy)
+        options("/:connection_id", ConnectionController, :handle_preflight)
+
         scope "/sse" do
           subscription_url = "/:connection_id/subscriptions"
           options(subscription_url, SubscriptionController, :handle_preflight)

--- a/lib/rig_inbound_gateway_web/router.ex
+++ b/lib/rig_inbound_gateway_web/router.ex
@@ -15,14 +15,6 @@ defmodule RigInboundGatewayWeb.Router do
       scope "/connection" do
         get("/init", ConnectionController, :init)
 
-        scope "/:connection_id" do
-          delete("/", ConnectionController, :destroy)
-          options("/", ConnectionController, :handle_preflight)
-
-          delete("/socket", ConnectionController, :destroy_connection)
-          options("/socket", ConnectionController, :handle_preflight)
-        end
-
         scope "/sse" do
           subscription_url = "/:connection_id/subscriptions"
           options(subscription_url, SubscriptionController, :handle_preflight)

--- a/lib/rig_inbound_gateway_web/v1/connection_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/connection_controller.ex
@@ -28,46 +28,4 @@ defmodule RigInboundGatewayWeb.V1.ConnectionController do
     |> with_allow_origin
     |> send_resp(:ok, Codec.serialize(vconnection_pid))
   end
-
-  @doc """
-  ### Dirty Testing
-
-      CONN_TOKEN=$(http :4000/_rig/v1/connection/init)
-      http delete ":4000/_rig/v1/connection/$CONN_TOKEN/"
-  """
-  @spec init(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
-  def destroy(
-        %{method: "DELETE"} = conn,
-        %{
-          "connection_id" => connection_id
-        }
-      ) do
-    {:ok, pid} = Codec.deserialize(connection_id)
-    Process.exit(pid, :kill)
-
-    conn
-    |> with_allow_origin
-    |> send_resp(:ok, "")
-  end
-
-  @doc """
-  ### Dirty Testing
-
-      CONN_TOKEN=$(http :4000/_rig/v1/connection/init)
-      http delete ":4000/_rig/v1/connection/$CONN_TOKEN/socket"
-  """
-  @spec init(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
-  def destroy_connection(
-        %{method: "DELETE"} = conn,
-        %{
-          "connection_id" => connection_id
-        }
-      ) do
-    {:ok, pid} = Codec.deserialize(connection_id)
-    send(pid, :kill_connection)
-
-    conn
-    |> with_allow_origin
-    |> send_resp(:ok, "")
-  end
 end

--- a/lib/rig_inbound_gateway_web/v1/connection_controller.ex
+++ b/lib/rig_inbound_gateway_web/v1/connection_controller.ex
@@ -2,7 +2,7 @@ defmodule RigInboundGatewayWeb.V1.ConnectionController do
   @moduledoc false
   use Rig.Config, [:cors]
   use RigInboundGatewayWeb, :controller
-  use RigInboundGatewayWeb.Cors, [:put, :delete]
+  use RigInboundGatewayWeb.Cors, [:get, :delete]
 
   alias Result
   alias Rig.Connection.Codec
@@ -27,5 +27,26 @@ defmodule RigInboundGatewayWeb.V1.ConnectionController do
     conn
     |> with_allow_origin
     |> send_resp(:ok, Codec.serialize(vconnection_pid))
+  end
+
+  @doc """
+  ### Dirty Testing
+
+      CONN_TOKEN=$(http :4000/_rig/v1/connection/init)
+      http delete ":4010/v2/connection/$CONN_TOKEN/"
+  """
+  @spec destroy(conn :: Plug.Conn.t(), params :: map) :: Plug.Conn.t()
+  def destroy(
+        %{method: "DELETE"} = conn,
+        %{
+          "connection_id" => connection_id
+        }
+      ) do
+    {:ok, pid} = Codec.deserialize(connection_id)
+    Process.exit(pid, :kill)
+
+    conn
+    |> with_allow_origin
+    |> send_resp(:ok, "")
   end
 end

--- a/lib/rig_inbound_gateway_web/v1/sse.ex
+++ b/lib/rig_inbound_gateway_web/v1/sse.ex
@@ -27,6 +27,7 @@ defmodule RigInboundGatewayWeb.V1.SSE do
     query_params = req |> :cowboy_req.parse_qs() |> Enum.into(%{})
     jwt = query_params["jwt"]
     connection_token = query_params["connection_token"]
+    last_event_id = query_params["last_event_id"]
 
     auth_info =
       case jwt do
@@ -44,7 +45,8 @@ defmodule RigInboundGatewayWeb.V1.SSE do
           query_params: "",
           content_type: "application/json; charset=utf-8",
           body: encoded_body_or_nil,
-          connection_token: connection_token
+          connection_token: connection_token,
+          last_event_id: last_event_id
         }
 
         do_init(req, request)

--- a/lib/rig_inbound_gateway_web/v1/websocket.ex
+++ b/lib/rig_inbound_gateway_web/v1/websocket.ex
@@ -38,6 +38,7 @@ defmodule RigInboundGatewayWeb.V1.Websocket do
   def websocket_init(%{query_params: query_params}) do
     jwt = query_params["jwt"]
     connection_token = query_params["connection_token"]
+    last_event_id = query_params["last_event_id"]
 
     auth_info =
       case jwt do
@@ -55,7 +56,8 @@ defmodule RigInboundGatewayWeb.V1.Websocket do
           query_params: "",
           content_type: "application/json; charset=utf-8",
           body: encoded_body_or_nil,
-          connection_token: connection_token
+          connection_token: connection_token,
+          last_event_id: last_event_id
         }
 
         do_init(request)

--- a/lib/rig_inbound_gateway_web/vconnection.ex
+++ b/lib/rig_inbound_gateway_web/vconnection.ex
@@ -13,13 +13,11 @@ defmodule RigInboundGatewayWeb.VConnection do
   require Logger
 
   use GenServer
-  use Rig.Config, [:idle_connection_timeout]
-
-  # TEMP UNTIL WE ACTUALLY IMPLEMENT lasteventid
-  @buffer_size 10
-  @send_interval 20
+  use Rig.Config, [:idle_connection_timeout, :connection_buffer_size, :resend_interval]
 
   def start(pid, subscriptions, heartbeat_interval_ms, subscription_refresh_interval_ms) do
+    %{connection_buffer_size: buffer_size} = config()
+    buffer_size = String.to_integer(buffer_size)
     GenServer.start(
       __MODULE__,
       %{
@@ -29,7 +27,7 @@ defmodule RigInboundGatewayWeb.VConnection do
         subscription_refresh_interval_ms: subscription_refresh_interval_ms,
         kill_timer: nil,
         monitor: nil,
-        event_buffer: EventBuffer.new(@buffer_size)
+        event_buffer: EventBuffer.new(buffer_size)
       }
     )
   end
@@ -98,13 +96,16 @@ defmodule RigInboundGatewayWeb.VConnection do
 
   @impl true
   def handle_info({:schedule_missing, last_event_id}, state) do
+    %{resend_interval: interval} = config()
+    interval = String.to_integer(interval)
+
     case EventBuffer.events_since(state.event_buffer, last_event_id) do
       {:ok, [events: []]} ->
         Logger.debug(fn -> "Received last_event_id but have no events to return #{inspect(self())}" end)
 
       {:ok, [events: events, last_event_id: _last_event_id]} ->
         Logger.debug(fn -> "Scheduling resending of buffered events #{inspect(self())}" end)
-        Process.send_after(self(), {:send_missing, events}, @send_interval)
+        Process.send_after(self(), {:send_missing, events}, interval)
 
       {:no_such_event, [not_found_id: _not_found_id, last_event_id: _last_event_id]} ->
         Logger.debug(fn -> "Received last_event_id but it is unknown #{inspect(self())}" end)
@@ -127,11 +128,14 @@ defmodule RigInboundGatewayWeb.VConnection do
   """
   @impl true
   def handle_info({:send_missing, [event | events]}, state) do
+    %{resend_interval: interval} = config()
+    interval = String.to_integer(interval)
+
     send self(), event
 
     if events != [] do
       # Schedule send of events that are left
-      Process.send_after(self(), {:send_missing, events}, @send_interval)
+      Process.send_after(self(), {:send_missing, events}, interval)
     end
     {:noreply, state}
   end

--- a/test/connection_init_test.exs
+++ b/test/connection_init_test.exs
@@ -6,11 +6,11 @@ defmodule RigInboundGatewayWeb.ConnectionInitTest do
   alias HTTPoison
   alias Rig.Connection.Codec
 
-  @base_url "http://localhost:4010/v2/connection"
+  @event_hub_http_port Confex.fetch_env!(:rig, RigInboundGatewayWeb.Endpoint)[:http][:port]
 
   describe "Initialize connection" do
     test "An SSE connection can be initialized in advance." do
-      url = "#{@base_url}/init"
+      url = "http://localhost:#{@event_hub_http_port}/_rig/v1/connection/init"
       %HTTPoison.Response{body: body} = HTTPoison.get!(url)
 
       assert {:ok, client} = SseClient.connect(connection_token: body)
@@ -22,11 +22,11 @@ defmodule RigInboundGatewayWeb.ConnectionInitTest do
     end
 
     test "A client can connect to a destroyed VConnection and will get assigned a new VConnection." do
-      url = "#{@base_url}/init"
+      url = "http://localhost:#{@event_hub_http_port}/_rig/v1/connection/init"
       %HTTPoison.Response{body: body} = HTTPoison.get!(url)
 
       # Destroy the VConnection
-      del_url = "#{@base_url}/#{body}"
+      del_url = "http://localhost:#{@event_hub_http_port}/_rig/v1/connection/#{body}"
       %HTTPoison.Response{} = HTTPoison.delete!(del_url)
 
       assert {:ok, client} = SseClient.connect(connection_token: body)

--- a/test/connection_init_test.exs
+++ b/test/connection_init_test.exs
@@ -26,7 +26,7 @@ defmodule RigInboundGatewayWeb.ConnectionInitTest do
       %HTTPoison.Response{body: body} = HTTPoison.get!(url)
 
       # Destroy the VConnection
-      del_url = "http://localhost:4010/v2/connection/#{body}"
+      del_url = "http://localhost:4000/_rig/v1/connection/#{body}"
       %HTTPoison.Response{} = HTTPoison.delete!(del_url)
 
       assert {:ok, client} = SseClient.connect(connection_token: body)

--- a/test/connection_init_test.exs
+++ b/test/connection_init_test.exs
@@ -6,11 +6,11 @@ defmodule RigInboundGatewayWeb.ConnectionInitTest do
   alias HTTPoison
   alias Rig.Connection.Codec
 
-  @event_hub_http_port Confex.fetch_env!(:rig, RigInboundGatewayWeb.Endpoint)[:http][:port]
+  @base_url "http://localhost:4010/v2/connection"
 
   describe "Initialize connection" do
     test "An SSE connection can be initialized in advance." do
-      url = "http://localhost:#{@event_hub_http_port}/_rig/v1/connection/init"
+      url = "#{@base_url}/init"
       %HTTPoison.Response{body: body} = HTTPoison.get!(url)
 
       assert {:ok, client} = SseClient.connect(connection_token: body)
@@ -22,11 +22,11 @@ defmodule RigInboundGatewayWeb.ConnectionInitTest do
     end
 
     test "A client can connect to a destroyed VConnection and will get assigned a new VConnection." do
-      url = "http://localhost:#{@event_hub_http_port}/_rig/v1/connection/init"
+      url = "#{@base_url}/init"
       %HTTPoison.Response{body: body} = HTTPoison.get!(url)
 
       # Destroy the VConnection
-      del_url = "http://localhost:#{@event_hub_http_port}/_rig/v1/connection/#{body}"
+      del_url = "#{@base_url}/#{body}"
       %HTTPoison.Response{} = HTTPoison.delete!(del_url)
 
       assert {:ok, client} = SseClient.connect(connection_token: body)

--- a/test/connection_init_test.exs
+++ b/test/connection_init_test.exs
@@ -26,7 +26,7 @@ defmodule RigInboundGatewayWeb.ConnectionInitTest do
       %HTTPoison.Response{body: body} = HTTPoison.get!(url)
 
       # Destroy the VConnection
-      del_url = "http://localhost:#{@event_hub_http_port}/_rig/v1/connection/#{body}"
+      del_url = "http://localhost:4010/v2/connection/#{body}"
       %HTTPoison.Response{} = HTTPoison.delete!(del_url)
 
       assert {:ok, client} = SseClient.connect(connection_token: body)

--- a/test/reconnect_test.exs
+++ b/test/reconnect_test.exs
@@ -34,9 +34,7 @@ defmodule RigInboundGatewayWeb.ReconnectTest do
 
     # Destroy the VConnection, this simulates a timeout
     url =
-      "http://localhost:#{@event_hub_http_port}/_rig/v1/connection/#{
-        event1["data"]["connection_token"]
-      }"
+      "http://localhost:4010/v2/connection/#{event1["data"]["connection_token"]}"
 
     %HTTPoison.Response{status_code: 200} = HTTPoison.delete!(url)
 

--- a/test/reconnect_test.exs
+++ b/test/reconnect_test.exs
@@ -34,7 +34,7 @@ defmodule RigInboundGatewayWeb.ReconnectTest do
 
     # Destroy the VConnection, this simulates a timeout
     url =
-      "http://localhost:4010/v2/connection/#{event1["data"]["connection_token"]}"
+      "http://localhost:4000/_rig/v1/connection/#{event1["data"]["connection_token"]}"
 
     %HTTPoison.Response{status_code: 200} = HTTPoison.delete!(url)
 


### PR DESCRIPTION
### **This doesn't close 154!**

## Description

To implement the session API, we needed to keep track of connection state, which, in turn, meant rewriting connection handling into a more abstract, generalized solution (`VConnection`).

Creating this VConnection allowed me to do all sorts of other cool stuff (pre-initialization of a connection and reconnects) which now segued into this PR.

As for use cases:

### Use case: Reconnect

Bob has the website of service x open on his laptop while sitting in a train from location a to location b when suddenly the train goes into a tunnel. Bob loses his internet connection. When the train leaves the tunnel, Bobs laptop regains internet connection. Lucky for Bob, service x uses RIG. Since Service x also uses RIG's `last_event_id` feature, Bob is able to pick up his session where he left off. 

### Use case: Pre-initialization of VConnection

This is more of a technical use case that allows for some nice frontend code when dealing with reconnections.

Something like:

```js
const baseUrl = "http://localhost:4000/_rig/v1"
let response = await fetch(`${baseUrl}/connection/init`, {
  method: "GET",
  mode: "cors"
})
const token = await response.text()

const connection_token = response.status == 200 ? `?connection_token=${token}` : ""
const eventUrl = `${baseUrl}/connection/sse${connection_token}`

source = new EventSource(eventUrl)
...
```

## What to look out for

Dear reviewer, I want you to

- check that the code works on your machine.
- suggest implementation-code design/structure/readability improvements.
- suggest test-code design/structure/readability improvements.
- suggest documentation improvements.
- suggest language/writing improvements.
- help to find bugs