### PR TITLE
DistributedSet: ignore peer timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
 
 <!-- ### Added -->
 
 <!-- ### Changed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- Fixed a bug where distributed set processes would crash when one of their peers has died but hasn't been removed yet from the pg2 group.
 
 <!-- ### Deprecated -->
 


### PR DESCRIPTION
Fixes a bug where distributed set processes would crash when one of
their peers has died but hasn't been removed yet from the pg2 group.

For example, consider three RIG nodes A, B and C. They are aware of each other so the blacklist pg2 group contains the DistributedSet processes of all three nodes. Let's say the network to C goes down. A and B will find out that they can no longer reach C eventually and remove the process on C from the pg2 group. But until that happens, the process on C stays in that group. If a sync happens in that time frame, the corresponding GenServer call will time out. Since the time-out is not handled, the DistributedSet process will crash. If the timing is right, this can happen to all DistributedSet processes before the process on C is actually removed from the pg2 group. If C doesn't come back, the blacklist is lost.
