### PR TITLE
221 response codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added validation for reverse proxy configuration. Now it crashes RIG on start when configuration is not valid or returns `400` when using REST API to update configuration. [#277](https://github.com/Accenture/reactive-interaction-gateway/issues/277)
 - Added basic distributed tracing support in [W3C Trace Context specification](https://www.w3.org/TR/trace-context/) with Jaeger and Openzipkin exporters. RIG opens a span at the API Gateway and emits trace context in Cloud Events following the [distributed tracing spec](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md). [#281](https://github.com/Accenture/reactive-interaction-gateway/issues/281)
 - Added possibility to set response code for `response_from` messages in reverse proxy (`kafka` and `http_async`). [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
+- Added new version - `v3` - for internal endpoints to support response code in the `/responses` endpoint
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support publishing events consumed from [NATS](https://nats.io) topics. See the [documentation](https://accenture.github.io/reactive-interaction-gateway/docs/event-streams.html#nats) for how to get started. [#297](https://github.com/Accenture/reactive-interaction-gateway/issues/297)
 - Added validation for reverse proxy configuration. Now it crashes RIG on start when configuration is not valid or returns `400` when using REST API to update configuration. [#277](https://github.com/Accenture/reactive-interaction-gateway/issues/277)
 - Added basic distributed tracing support in [W3C Trace Context specification](https://www.w3.org/TR/trace-context/) with Jaeger and Openzipkin exporters. RIG opens a span at the API Gateway and emits trace context in Cloud Events following the [distributed tracing spec](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md). [#281](https://github.com/Accenture/reactive-interaction-gateway/issues/281)
-- Added possibility to set response code for `response_from` messages in reverse proxy. [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
+- Added possibility to set response code for `response_from` messages in reverse proxy (`kafka` and `http_async`). [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
 
 ### Changed
 
 - Incorporated [cloudevents-ex](https://github.com/kevinbader/cloudevents-ex) to handle binary and structured modes for [Kafka protocol binding](https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md) in a proper way. This introduces some **breaking changes**:
   - Binary mode is now using `ce_` prefix for CloudEvents context attribute headers, before it was `ce-` - done according to the [Kafka protocol binding](https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md)
 - Change above affects also `"response_from": "kafka"` proxy functionality. RIG will forward to clients only Kafka body, no headers. This means, when using binary mode, clients receive only the data part, no CloudEvents context attributes.
-- Changed `response_from` handler to expect a message in binary format, **NOT** a cloud event. [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
+- Changed `response_from` handler to expect a message in binary format, **NOT** a cloud event (`kafka` and `http_async`). [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support publishing events consumed from [NATS](https://nats.io) topics. See the [documentation](https://accenture.github.io/reactive-interaction-gateway/docs/event-streams.html#nats) for how to get started. [#297](https://github.com/Accenture/reactive-interaction-gateway/issues/297)
 - Added validation for reverse proxy configuration. Now it crashes RIG on start when configuration is not valid or returns `400` when using REST API to update configuration. [#277](https://github.com/Accenture/reactive-interaction-gateway/issues/277)
 - Added basic distributed tracing support in [W3C Trace Context specification](https://www.w3.org/TR/trace-context/) with Jaeger and Openzipkin exporters. RIG opens a span at the API Gateway and emits trace context in Cloud Events following the [distributed tracing spec](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md). [#281](https://github.com/Accenture/reactive-interaction-gateway/issues/281)
-- Added possibility to set response code and response headers (structured mode only) for `response_from` messages in reverse proxy. [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
+- Added possibility to set response code for `response_from` messages in reverse proxy. [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
 
 ### Changed
 
 - Incorporated [cloudevents-ex](https://github.com/kevinbader/cloudevents-ex) to handle binary and structured modes for [Kafka protocol binding](https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md) in a proper way. This introduces some **breaking changes**:
   - Binary mode is now using `ce_` prefix for CloudEvents context attribute headers, before it was `ce-` - done according to the [Kafka protocol binding](https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md)
 - Change above affects also `"response_from": "kafka"` proxy functionality. RIG will forward to clients only Kafka body, no headers. This means, when using binary mode, clients receive only the data part, no CloudEvents context attributes.
-- Changed `response_from` handler to expect a message, **NOT** a cloud event. [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
+- Changed `response_from` handler to expect a message in binary format, **NOT** a cloud event. [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support publishing events consumed from [NATS](https://nats.io) topics. See the [documentation](https://accenture.github.io/reactive-interaction-gateway/docs/event-streams.html#nats) for how to get started. [#297](https://github.com/Accenture/reactive-interaction-gateway/issues/297)
 - Added validation for reverse proxy configuration. Now it crashes RIG on start when configuration is not valid or returns `400` when using REST API to update configuration. [#277](https://github.com/Accenture/reactive-interaction-gateway/issues/277)
 - Added basic distributed tracing support in [W3C Trace Context specification](https://www.w3.org/TR/trace-context/) with Jaeger and Openzipkin exporters. RIG opens a span at the API Gateway and emits trace context in Cloud Events following the [distributed tracing spec](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md). [#281](https://github.com/Accenture/reactive-interaction-gateway/issues/281)
+- Added possibility to set response code and response headers (structured mode only) for `response_from` messages in reverse proxy. [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
 
 ### Changed
 
 - Incorporated [cloudevents-ex](https://github.com/kevinbader/cloudevents-ex) to handle binary and structured modes for [Kafka protocol binding](https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md) in a proper way. This introduces some **breaking changes**:
   - Binary mode is now using `ce_` prefix for CloudEvents context attribute headers, before it was `ce-` - done according to the [Kafka protocol binding](https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md)
 - Change above affects also `"response_from": "kafka"` proxy functionality. RIG will forward to clients only Kafka body, no headers. This means, when using binary mode, clients receive only the data part, no CloudEvents context attributes.
+- Changed `response_from` handler to expect a message, **NOT** a cloud event. [#321](https://github.com/Accenture/reactive-interaction-gateway/pull/321)
 
 ### Fixed
 

--- a/config/rig_api/config.exs
+++ b/config/rig_api/config.exs
@@ -45,6 +45,7 @@ config :phoenix, :serve_endpoints, true
 
 config :rig, RigApi.V1.APIs, rig_proxy: RigInboundGateway.Proxy
 config :rig, RigApi.V2.APIs, rig_proxy: RigInboundGateway.Proxy
+config :rig, RigApi.V3.APIs, rig_proxy: RigInboundGateway.Proxy
 
 config :rig, :event_filter, Rig.EventFilter
 

--- a/config/rig_api/test.exs
+++ b/config/rig_api/test.exs
@@ -10,5 +10,6 @@ config :rig, RigApi.Endpoint,
 
 config :rig, RigApi.V1.APIs, rig_proxy: RigInboundGateway.ProxyMock
 config :rig, RigApi.V2.APIs, rig_proxy: RigInboundGateway.ProxyMock
+config :rig, RigApi.V3.APIs, rig_proxy: RigInboundGateway.ProxyMock
 
 config :rig, :event_filter, Rig.EventFilterMock

--- a/config/rig_inbound_gateway/config.exs
+++ b/config/rig_inbound_gateway/config.exs
@@ -172,6 +172,9 @@ config :rig, RigInboundGatewayWeb.V1.SubscriptionController, cors: cors
 config :rig, RigInboundGatewayWeb.V1.SSE, cors: cors
 config :rig, RigInboundGatewayWeb.V1.LongpollingController, cors: cors
 
+config :rig, RigInboundGateway.ApiProxy.ResponseFromParser,
+  schema_registry_host: {:system, "KAFKA_SCHEMA_REGISTRY_HOST", nil}
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/rig_inbound_gateway/config.exs
+++ b/config/rig_inbound_gateway/config.exs
@@ -172,9 +172,6 @@ config :rig, RigInboundGatewayWeb.V1.SubscriptionController, cors: cors
 config :rig, RigInboundGatewayWeb.V1.SSE, cors: cors
 config :rig, RigInboundGatewayWeb.V1.LongpollingController, cors: cors
 
-config :rig, RigInboundGateway.ApiProxy.ResponseFromParser,
-  schema_registry_host: {:system, "KAFKA_SCHEMA_REGISTRY_HOST", nil}
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -212,7 +212,7 @@ Configuration of such API endpoint might look like this:
 - Kinesis -> **not supported**
 - Nats -> `nats`
 
-`http_async` means that correlated response has to be sent to internal `:4010/v2/responses` `POST` endpoint.
+`http_async` means that correlated response has to be sent to internal `:4010/v3/responses` `POST` endpoint.
 
 #### Supported formats
 
@@ -223,9 +223,10 @@ Message headers:
 ```plaintext
 rig-correlation: "correlation_id_sent_by_rig"
 rig-response-code: "201"
+content-type: "application/json"
 ```
 
-> Both headers are required.
+> All headers are required.
 
 Message body:
 

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -218,9 +218,7 @@ Configuration of such API endpoint might look like this:
 
 #### Supported formats
 
-All `response_from` options are using message structures as below.
-
-##### Binary
+All `response_from` options support only binary mode.
 
 Message headers:
 
@@ -229,7 +227,7 @@ rig-correlation: "correlation_id_sent_by_rig"
 rig-response-code: "201"
 ```
 
-> `rig-correlation` is required.
+> Both headers are required.
 
 Message body:
 
@@ -238,27 +236,6 @@ Message body:
   "foo": "bar"
 }
 ```
-
-##### Structured
-
-Message body:
-
-```json
-{
-  "rig": {
-    "correlation": "correlation_id_sent_by_rig",
-    "response_code": 201
-  },
-  "headers": {
-    "foo": "bar"
-  },
-  "body": {
-    "foo": "bar"
-  }
-}
-```
-
-> `rig.correlation` is required.
 
 ## Auth
 

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -214,8 +214,6 @@ Configuration of such API endpoint might look like this:
 
 `http_async` means that correlated response has to be sent to internal `:4010/v2/responses` `POST` endpoint.
 
-`response_from="kafka"` will try to decode Avro encoded message.
-
 #### Supported formats
 
 All `response_from` options support only binary mode.

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -180,9 +180,7 @@ The endpoint expects the following request format:
 ### Wait for response
 
 Sometimes it makes sense to provide a simple request-response API to something that runs asynchronously on the backend. For example, let's say there's a ticket reservation process that takes 10 seconds in total and involves three different services that communicate via message passing. For an external client, it may be simpler to wait 10 seconds for the response instead of polling for a response every other second.
-A behavior like this can be configured using an endpoints' `response_from` property. When set to `kafka`, the response to the request is not taken from the `target` (e.g., for `target` = `http` this means the backend's HTTP response is ignored), but instead it's read from a Kafka topic. In order to enable RIG to correlate the response from the topic with the original request, RIG adds a correlation ID to the request (using a query parameter in case of `target` = `http`, or backed into the produced CloudEvent otherwise). Backend services that work with the request need to include that correlation ID in their response; otherwise, RIG won't be able to forward it to the client (and times out).
-
-> In case you want to use _binary_ transport mode, make sure that `rig` extension (containing correlation ID) is prefixed with `ce_` as well.
+A behavior like this can be configured using an endpoints' `response_from` property. When set to `kafka`, the response to the request is not taken from the `target` (e.g., for `target` = `http` this means the backend's HTTP response is ignored), but instead it's read from a Kafka topic. In order to enable RIG to correlate the response from the topic with the original request, RIG adds a correlation ID to the request (using a query parameter in case of `target` = `http`, or backed into the produced CloudEvent otherwise). **Backend services that work with the request need to include that correlation ID in their response; otherwise, RIG won't be able to forward it to the client (and times out).**
 
 Configuration of such API endpoint might look like this:
 
@@ -207,25 +205,60 @@ Configuration of such API endpoint might look like this:
 
 > Note the presence of `response_from` field. This tells RIG to wait for different event with the same correlation ID.
 
-As an alternative you can set `response_from` to `http_async`. This means that correlated response has to be sent to internal `:4010/v2/responses` `POST` endpoint with a body like this:
+#### Supported combinations (`target` -> `response_from`)
+
+- HTTP -> `kafka`/`http_async`/`kinesis`
+- Kafka -> `kafka`
+- Kinesis -> **not supported**
+- Nats -> `nats`
+
+`http_async` means that correlated response has to be sent to internal `:4010/v2/responses` `POST` endpoint.
+
+`response_from="kafka"` will try to decode Avro encoded message.
+
+#### Supported formats
+
+All `response_from` options are using message structures as below.
+
+##### Binary
+
+Message headers:
+
+```plaintext
+rig-correlation: "correlation_id_sent_by_rig"
+rig-response-code: "201"
+```
+
+> `rig-correlation` is required.
+
+Message body:
 
 ```json
 {
-  "id": "1",
-  "specversion": "0.2",
-  "source": "my-service",
-  "type": "com.example",
-  "rig": {
-    "correlation": "_id_"
-  },
-  "data": {
-    ...
-  }
-  ...
+  "foo": "bar"
 }
 ```
 
-> **NOTE:** Kinesis doesn't support `response_from` field yet.
+##### Structured
+
+Message body:
+
+```json
+{
+  "rig": {
+    "correlation": "correlation_id_sent_by_rig",
+    "response_code": 201
+  },
+  "headers": {
+    "foo": "bar"
+  },
+  "body": {
+    "foo": "bar"
+  }
+}
+```
+
+> `rig.correlation` is required.
 
 ## Auth
 

--- a/lib/rig_api/router.ex
+++ b/lib/rig_api/router.ex
@@ -75,6 +75,32 @@ defmodule RigApi.Router do
     end
   end
 
+  scope "/v3", RigApi.V3 do
+    scope "/apis" do
+      pipe_through(:body_parser)
+      get("/", APIs, :list_apis)
+      post("/", APIs, :add_api)
+      get("/:id", APIs, :get_api_detail)
+      put("/:id", APIs, :update_api)
+      delete("/:id", APIs, :deactivate_api)
+    end
+
+    scope "/messages" do
+      post("/", Messages, :publish)
+    end
+
+    scope "/responses" do
+      pipe_through(:body_parser)
+      resources("/", Responses, only: [:create])
+    end
+
+    scope "/session-blacklist" do
+      pipe_through(:body_parser)
+      post("/", SessionBlacklist, :blacklist_session)
+      get("/:session_id", SessionBlacklist, :check_status)
+    end
+  end
+
   def swagger_info do
     %{
       info: %{

--- a/lib/rig_api/v1/responses.ex
+++ b/lib/rig_api/v1/responses.ex
@@ -37,12 +37,12 @@ defmodule RigApi.V1.Responses do
   """
   def create(%{req_headers: req_headers} = conn, message) do
     case ResponseFromParser.parse(req_headers, message) do
-      {deserialized_pid, response_code, response, response_headers} ->
+      {deserialized_pid, response_code, response} ->
         Logger.debug(fn ->
           "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
         end)
 
-        send(deserialized_pid, {:response_received, response, response_code, response_headers})
+        send(deserialized_pid, {:response_received, response, response_code})
         send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
 
       err ->

--- a/lib/rig_api/v1/responses.ex
+++ b/lib/rig_api/v1/responses.ex
@@ -5,8 +5,7 @@ defmodule RigApi.V1.Responses do
   use RigApi, :controller
   use PhoenixSwagger
 
-  alias Rig.Connection.Codec
-  alias RigCloudEvents.CloudEvent
+  alias RigInboundGateway.ApiProxy.ResponseFromParser
 
   @prefix "/v1"
 
@@ -36,18 +35,16 @@ defmodule RigApi.V1.Responses do
 
   Note that body has to contain following field `"rig": { "correlation": "_id_" }`.
   """
-  def create(conn, message) do
-    with {:ok, cloud_event} <- CloudEvent.parse(message),
-         {:ok, rig_metadata} <- Map.fetch(message, "rig"),
-         {:ok, correlation_id} <- Map.fetch(rig_metadata, "correlation"),
-         {:ok, deserialized_pid} <- Codec.deserialize(correlation_id) do
-      Logger.debug(fn ->
-        "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
-      end)
+  def create(%{req_headers: req_headers} = conn, message) do
+    case ResponseFromParser.parse(req_headers, message) do
+      {deserialized_pid, response_code, response, response_headers} ->
+        Logger.debug(fn ->
+          "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
+        end)
 
-      send(deserialized_pid, {:response_received, cloud_event.json})
-      send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
-    else
+        send(deserialized_pid, {:response_received, response, response_code, response_headers})
+        send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
+
       err ->
         Logger.warn(fn -> "Parse error #{inspect(err)} for #{inspect(message)}" end)
 

--- a/lib/rig_api/v2/responses.ex
+++ b/lib/rig_api/v2/responses.ex
@@ -37,12 +37,12 @@ defmodule RigApi.V2.Responses do
   """
   def create(%{req_headers: req_headers} = conn, message) do
     case ResponseFromParser.parse(req_headers, message) do
-      {deserialized_pid, response_code, response, response_headers} ->
+      {deserialized_pid, response_code, response} ->
         Logger.debug(fn ->
           "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
         end)
 
-        send(deserialized_pid, {:response_received, response, response_code, response_headers})
+        send(deserialized_pid, {:response_received, response, response_code})
         send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
 
       err ->

--- a/lib/rig_api/v2/responses.ex
+++ b/lib/rig_api/v2/responses.ex
@@ -9,6 +9,7 @@ defmodule RigApi.V2.Responses do
   alias RigCloudEvents.CloudEvent
 
   @prefix "/v2"
+  @default_response_code 200
 
   action_fallback(RigApi.Fallback)
 
@@ -31,21 +32,50 @@ defmodule RigApi.V2.Responses do
     response(400, "Bad Request: Failed to parse request body :parse-error")
   end
 
+  defp parse_response_from(
+         _headers,
+         %{
+           "body" => body,
+           "rig" => rig_metadata
+         } = message
+       ) do
+    {:ok, correlation_id} = Map.fetch(rig_metadata, "correlation")
+    {:ok, deserialized_pid} = Codec.deserialize(correlation_id)
+    response_code = Map.get(rig_metadata, "response_code", 200)
+    response_headers = Map.get(message, "headers", %{})
+
+    {deserialized_pid, response_code, body, response_headers}
+  end
+
+  defp parse_response_from(
+         headers,
+         message
+       ) do
+    headers_map = Enum.into(headers, %{})
+    {:ok, correlation_id} = Map.fetch(headers_map, "rig-correlation")
+    {:ok, deserialized_pid} = Codec.deserialize(correlation_id)
+
+    {response_code, _} =
+      headers_map
+      |> Map.get("rig-response-code", "200")
+      |> Integer.parse()
+
+    {deserialized_pid, response_code, Jason.encode!(message), %{}}
+  end
+
   @doc """
   Accepts message to be sent to correlated HTTP process.
 
   Note that body has to contain following field `"rig": { "correlation": "_id_" }`.
   """
-  def create(conn, message) do
-    with {:ok, cloud_event} <- CloudEvent.parse(message),
-         {:ok, rig_metadata} <- Map.fetch(message, "rig"),
-         {:ok, correlation_id} <- Map.fetch(rig_metadata, "correlation"),
-         {:ok, deserialized_pid} <- Codec.deserialize(correlation_id) do
+  def create(%{req_headers: req_headers} = conn, message) do
+    with {deserialized_pid, response_code, response, response_headers} <-
+           parse_response_from(req_headers, message) do
       Logger.debug(fn ->
         "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
       end)
 
-      send(deserialized_pid, {:response_received, cloud_event.json})
+      send(deserialized_pid, {:response_received, response, response_code, response_headers})
       send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
     else
       err ->

--- a/lib/rig_api/v3/apis.ex
+++ b/lib/rig_api/v3/apis.ex
@@ -1,0 +1,357 @@
+defmodule RigApi.V3.APIs do
+  @moduledoc "CRUD controller for the reverse-proxy settings."
+  use Rig.Config, [:rig_proxy]
+  use RigApi, :controller
+  use PhoenixSwagger
+
+  alias RigInboundGateway.ApiProxy.Validations
+
+  require Logger
+
+  @prefix "/v3"
+
+  swagger_path :list_apis do
+    get(@prefix <> "/apis")
+    summary("List current proxy API-definitions.")
+    response(200, "Ok", Schema.ref(:ProxyAPIList))
+  end
+
+  def list_apis(conn, _params) do
+    %{rig_proxy: proxy} = config()
+    api_defs = proxy.list_apis(proxy)
+    active_apis = for {_, api} <- api_defs, api["active"], do: api
+    send_response(conn, 200, active_apis)
+  end
+
+  # ---
+
+  swagger_path :get_api_detail do
+    get(@prefix <> "/apis/{apiId}")
+    summary("Obtain details on a proxy API-definition.")
+
+    parameters do
+      apiId(:path, :string, "API definition identifier", required: true, example: "new-service")
+    end
+
+    response(200, "Ok", Schema.ref(:ProxyAPI))
+    response(404, "Doesn't exist", Schema.ref(:ProxyAPIResponse))
+  end
+
+  def get_api_detail(conn, params) do
+    %{"id" => id} = params
+
+    case get_active_api(id) do
+      api when api == nil or api == :inactive ->
+        send_response(conn, 404, %{message: "API with id=#{id} doesn't exists."})
+
+      {_id, api} ->
+        send_response(conn, 200, api)
+    end
+  end
+
+  # ---
+
+  swagger_path :add_api do
+    post(@prefix <> "/apis")
+    summary("Register a new proxy API-definition.")
+
+    parameters do
+      proxyAPI(
+        :body,
+        Schema.ref(:ProxyAPI),
+        "The details for the new Proxy endpoint",
+        required: true
+      )
+    end
+
+    response(201, "Ok", Schema.ref(:ProxyAPIResponse))
+    response(409, "Already exists", Schema.ref(:ProxyAPIResponse))
+  end
+
+  def add_api(conn, params) do
+    %{"id" => id} = params
+    %{rig_proxy: proxy} = config()
+
+    with {:ok, _api} <- Validations.validate(params),
+         nil <- proxy.get_api(proxy, id),
+         {:ok, _phx_ref} <- proxy.add_api(proxy, id, params) do
+      send_response(conn, 201, %{message: "ok"})
+    else
+      {_id, %{"active" => true}} ->
+        send_response(conn, 409, %{message: "API with id=#{id} already exists."})
+
+      {:error, errors} ->
+        send_response(conn, 400, Validations.to_map(errors))
+
+      {_id, %{"active" => false} = prev_api} ->
+        {:ok, _phx_ref} = proxy.replace_api(proxy, id, prev_api, params)
+        send_response(conn, 201, %{message: "ok"})
+    end
+  end
+
+  # ---
+
+  swagger_path :update_api do
+    put(@prefix <> "/apis/{apiId}")
+    summary("Update a proxy API-definition.")
+
+    parameters do
+      apiId(:path, :string, "API definition identifier", required: true, example: "new-service")
+
+      proxyAPI(
+        :body,
+        Schema.ref(:ProxyAPI),
+        "The details for the new Proxy endpoint",
+        required: true
+      )
+    end
+
+    response(200, "Ok", Schema.ref(:ProxyAPIResponse))
+    response(404, "Doesn't exist", Schema.ref(:ProxyAPIResponse))
+  end
+
+  def update_api(conn, params) do
+    %{"id" => id} = params
+
+    with {:ok, _api} <- Validations.validate(params),
+         {_id, current_api} <- get_active_api(id),
+         {:ok, _phx_ref} <- merge_and_update(id, current_api, params) do
+      send_response(conn, 200, %{message: "ok"})
+    else
+      {:error, errors} ->
+        send_response(conn, 400, Validations.to_map(errors))
+
+      api when api == nil or api == :inactive ->
+        send_response(conn, 404, %{message: "API with id=#{id} doesn't exists."})
+    end
+  end
+
+  # ---
+
+  swagger_path :deactivate_api do
+    delete(@prefix <> "/apis/{apiId}")
+    summary("Deactivate a proxy API-definition.")
+
+    parameters do
+      apiId(:path, :string, "API definition identifier", required: true, example: "new-service")
+    end
+
+    response(204, "")
+    response(404, "Doesn't exist", Schema.ref(:ProxyAPIResponse))
+  end
+
+  def deactivate_api(conn, params) do
+    %{"id" => id} = params
+    %{rig_proxy: proxy} = config()
+
+    with {_id, _current_api} <- get_active_api(id),
+         {:ok, _phx_ref} <- proxy.deactivate_api(proxy, id) do
+      send_response(conn, :no_content)
+    else
+      api when api == nil or api == :inactive ->
+        send_response(conn, 404, %{message: "API with id=#{id} doesn't exists."})
+    end
+  end
+
+  # ---
+
+  defp get_active_api(id) do
+    %{rig_proxy: proxy} = config()
+
+    with {id, current_api} <- proxy.get_api(proxy, id),
+         true <- current_api["active"] == true do
+      {id, current_api}
+    else
+      nil -> nil
+      false -> :inactive
+      _ -> :error
+    end
+  end
+
+  # ---
+
+  defp merge_and_update(id, current_api, updated_api) do
+    %{rig_proxy: proxy} = config()
+    merged_api = current_api |> Map.merge(updated_api)
+    proxy.update_api(proxy, id, merged_api)
+  end
+
+  # ---
+
+  defp send_response(conn, :no_content) do
+    conn
+    |> put_status(:no_content)
+    |> text("")
+  end
+
+  defp send_response(conn, status_code, body \\ %{}) do
+    conn
+    |> put_status(status_code)
+    |> json(body)
+  end
+
+  # ---
+
+  def swagger_definitions do
+    %{
+      ProxyAPI:
+        swagger_schema do
+          title("Proxy API Object")
+          description("An Proxy API object - Is used for creating/updating/reading")
+
+          properties do
+            id(:string, "Proxy API ID", required: true, example: "new-service")
+            name(:string, "Proxy API Name", required: true, example: "new-service")
+            auth_type(:string, "Authorization type", required: false, example: "jwt")
+
+            auth(
+              Schema.new do
+                properties do
+                  use_header(:boolean, "Authorization Header Usage", default: false, example: true)
+
+                  header_name(:string, "Authorization Header Name",
+                    required: false,
+                    example: "Authorization"
+                  )
+
+                  use_query(:boolean, "Authorization Header Query Usage",
+                    default: false,
+                    example: false
+                  )
+
+                  query_name(:string, "Authorization Header Query Name", required: false)
+                end
+              end
+            )
+
+            timestamp(:string, "creation timestamp",
+              required: false,
+              example: "2018-12-17T10:38:06.334013Z"
+            )
+
+            transform_request_headers(
+              Schema.new do
+                properties do
+                  add_headers(
+                    Schema.new do
+                      properties do
+                        my_header_name(:string, "New header value", example: "some header value")
+                      end
+                    end
+                  )
+                end
+              end
+            )
+
+            ref_number(:integer, "reference number", required: false, example: 0)
+            node_name(:string, "Node name", required: false, example: "nonode@nohost")
+            active(:boolean, "ID Status", required: false, example: true)
+            phx_ref(:string, "Phoenix Reference", required: false, example: "ewTJVcM7Bzc=")
+            versioned(:boolean, "is Versioned Endpoint?", default: false, example: false)
+
+            version_data(
+              Schema.new do
+                properties do
+                  default(
+                    Schema.new do
+                      properties do
+                        endpoints(Schema.ref(:ProxyAPIEndpointArray))
+                      end
+                    end
+                  )
+                end
+              end
+            )
+
+            proxy(
+              Schema.new do
+                properties do
+                  use_env(
+                    :boolean,
+                    "Whether to take the 'target_url' from environment variable or not",
+                    default: true,
+                    example: true
+                  )
+
+                  target_url(:string, "Proxy Target URL", required: true, example: "IS_HOST")
+                  port(:integer, "Proxy Port", required: true, example: 6666)
+                end
+              end
+            )
+          end
+        end,
+      ProxyAPIEndpointArray:
+        swagger_schema do
+          title("Proxy API Endpoint Array")
+          description("Array of Endpoints for the Proxy API")
+          type(:array)
+          items(Schema.ref(:ProxyAPIEndpoint))
+        end,
+      ProxyAPIEndpoint:
+        swagger_schema do
+          title("Proxy API Endpoint")
+          description("Endpoint for the Proxy API for Request")
+
+          properties do
+            id(:string, "Endpoint ID", required: true, example: "get-auth-register")
+
+            path(:string, "Endpoint path. Curly braces may be used to ignore parts of the path.",
+              required: true,
+              example: "/auth/register/{user}"
+            )
+
+            path_regex(
+              :string,
+              "Endpoint path, given as a regular expression (note that JSON requires escaping backslash characters).",
+              required: false,
+              example: "/auth/register/(.+)"
+            )
+
+            path_replacement(
+              :string,
+              "If given, the request path is rewritten. When used with `path_regex`, capture groups can be referenced by number (note that JSON requires escaping backslash characters).",
+              required: false,
+              example: ~S"/auth/register/\1"
+            )
+
+            method(:string, "Endpoint HTTP method", required: true, example: "GET")
+            secured(:boolean, "Endpoint Security", default: false, example: false)
+
+            transform_request_headers(:boolean, "Transform request headers",
+              default: false,
+              example: false
+            )
+
+            target(:string, "Request target - HTTP, Kafka or Kinesis",
+              default: "http",
+              example: "http"
+            )
+
+            topic(:string, "Kafka/Kinesis topic", example: "kafka-topic")
+            schema(:string, "Kafka Avro schema", example: "avro-schema")
+
+            response_from(:string, "Wait for asynchronnous response from HTTP, Kafka or Kinesis",
+              default: "http",
+              example: "http"
+            )
+          end
+        end,
+      ProxyAPIResponse:
+        swagger_schema do
+          title("Proxy API Response")
+          description("Proxy API Response")
+
+          properties do
+            message(:string, "Response", required: true, example: "ok")
+          end
+        end,
+      ProxyAPIList:
+        swagger_schema do
+          title("Proxy API List")
+          description(" A List of parameterized Proxy APIs")
+          type(:array)
+          items(Schema.ref(:ProxyAPI))
+        end
+    }
+  end
+end

--- a/lib/rig_api/v3/apis_test.exs
+++ b/lib/rig_api/v3/apis_test.exs
@@ -1,0 +1,558 @@
+defmodule RigApi.V3.APIsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use RigApi.ConnCase
+
+  alias RigInboundGateway.ProxyConfig
+
+  require Logger
+
+  @invalid_config_id "invalid-config"
+
+  describe "GET /v3/apis" do
+    test "should return list of APIs and filter deactivated APIs" do
+      conn = build_conn() |> get("/v3/apis")
+      assert json_response(conn, 200) |> length == 1
+    end
+  end
+
+  describe "GET /v3/apis/:id" do
+    test "should return requested API" do
+      conn = build_conn() |> get("/v3/apis/new-service")
+      response = json_response(conn, 200)
+      assert response["id"] == "new-service"
+    end
+
+    test "should 404 if requested API doesn't exist" do
+      conn = build_conn() |> get("/v3/apis/fake-service")
+      response = json_response(conn, 404)
+      assert response["message"] == "API with id=fake-service doesn't exists."
+    end
+
+    test "should return 404 if API exists, but is deactivated" do
+      conn = build_conn() |> get("/v3/apis/another-service")
+      response = json_response(conn, 404)
+      assert response["message"] == "API with id=another-service doesn't exists."
+    end
+  end
+
+  describe "POST /v3/apis" do
+    test "should add new API" do
+      new_api = @mock_api |> Map.put("id", "different-id")
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 201)
+      assert response["message"] == "ok"
+    end
+
+    test "should return 409 if API already exist" do
+      conn = build_conn() |> post("/v3/apis", @mock_api)
+      response = json_response(conn, 409)
+      assert response["message"] == "API with id=new-service already exists."
+    end
+
+    test "should replaced deactivated API with same ID" do
+      new_api = @mock_api |> Map.put("id", "another-service")
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 201)
+      assert response["message"] == "ok"
+    end
+
+    test "should return 400 when target is set to kafka or kinesis, but topic is not" do
+      # kinesis topic not set
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo",
+          "target" => "kinesis"
+        }
+      ]
+
+      kinesis_orig_value = ProxyConfig.set("PROXY_KINESIS_REQUEST_STREAM", "")
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"kinesis_request_stream" => "must be present"},
+                 %{"topic" => "must be present"}
+               ]
+             }
+
+      ProxyConfig.restore("PROXY_KINESIS_REQUEST_STREAM", kinesis_orig_value)
+
+      # kafka topic not set
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo",
+          "target" => "kafka"
+        }
+      ]
+
+      kafka_orig_value = ProxyConfig.set("PROXY_KAFKA_REQUEST_TOPIC", "")
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"kafka_request_topic" => "must be present"},
+                 %{"topic" => "must be present"}
+               ]
+             }
+
+      ProxyConfig.restore("PROXY_KAFKA_REQUEST_TOPIC", kafka_orig_value)
+    end
+
+    test "should return 400 when schema is set, but target is not kafka or kinesis" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo",
+          "schema" => "some-avro-schema"
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"target" => "must be present"}
+               ]
+             }
+    end
+
+    test "should return 400 when secured is set, but auth_type is not jwt" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo",
+          "secured" => true
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"auth_type" => "must be one of [\"jwt\"]"}
+               ]
+             }
+    end
+
+    test "should return 400 when use_header is set, but header_name is not" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo"
+        }
+      ]
+
+      auth = %{"use_header" => true}
+      auth_type = "jwt"
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth, auth_type)
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config" => [%{"header_name" => "must be present"}]
+             }
+    end
+
+    test "should return 400 when use_query is set, but query_name is not" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo"
+        }
+      ]
+
+      auth = %{"use_query" => true}
+      auth_type = "jwt"
+
+      ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth, auth_type)
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth, auth_type)
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config" => [%{"query_name" => "must be present"}]
+             }
+    end
+
+    test "should return 400 when auth is set, but auth_type is not" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo"
+        }
+      ]
+
+      auth = %{"use_query" => true, "query_name" => "test"}
+
+      ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth)
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth)
+      conn = build_conn() |> post("/v3/apis", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config" => [%{"auth_type" => "must be one of [\"jwt\"]"}]
+             }
+    end
+  end
+
+  describe "PUT /v3/apis/:id" do
+    test "should update requested API" do
+      conn = build_conn() |> put("/v3/apis/new-service", @mock_api)
+      response = json_response(conn, 200)
+      assert response["message"] == "ok"
+    end
+
+    test "should return 404 if requested API doesn't exist" do
+      conn =
+        build_conn()
+        |> put("/v3/apis/fake-service", %{
+          "id" => "fake",
+          "name" => "fake",
+          "version_data" => %{"default" => %{"endpoints" => []}},
+          "proxy" => %{
+            "port" => 3000,
+            "target_url" => "http://localhost"
+          }
+        })
+
+      response = json_response(conn, 404)
+      assert response["message"] == "API with id=fake-service doesn't exists."
+    end
+
+    test "should return 404 if API exists, but is deactivated" do
+      conn = build_conn() |> put("/v3/apis/another-service", @mock_api)
+      response = json_response(conn, 404)
+      assert response["message"] == "API with id=another-service doesn't exists."
+    end
+
+    test "should return 400 when api doesn't have required top level properties 'id', 'name', 'proxy' and 'version_data'" do
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", %{})
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "api" => [
+                 %{"name" => "must be string"},
+                 %{"name" => "must have a length of at least 1"},
+                 %{"proxy" => "must be present"},
+                 %{"version_data" => "must be present"}
+               ]
+             }
+    end
+
+    test "should return 400 when 'proxy' doesn't have required properties 'target_url' and 'port'" do
+      new_api = %{
+        "id" => "invalid_proxy",
+        "name" => "invalid_proxy",
+        "proxy" => %{},
+        "version_data" => %{
+          "default" => %{
+            "endpoints" => []
+          }
+        }
+      }
+
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "api" => [
+                 %{"proxy" => "must be present"},
+                 %{"target_url" => "must be string"},
+                 %{"target_url" => "must have a length of at least 1"},
+                 %{"port" => "must be integer"}
+               ]
+             }
+    end
+
+    test "should return 400 when 'version_data' doesn't have any version" do
+      new_api = %{
+        "id" => "invalid_proxy",
+        "name" => "invalid_proxy",
+        "proxy" => %{
+          "port" => 3000,
+          "target_url" => "http://localhost"
+        },
+        "version_data" => %{}
+      }
+
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "api" => [
+                 %{"version_data" => "must be present"},
+                 %{
+                   "version_data" => "must have at least one version, e.g. default"
+                 }
+               ]
+             }
+    end
+
+    test "should return 400 when 'default' version doesn't have 'endpoints' property or is not a list" do
+      # missing "endpoints" property
+      new_api = %{
+        "id" => "invalid_proxy",
+        "name" => "invalid_proxy",
+        "proxy" => %{
+          "port" => 3000,
+          "target_url" => "http://localhost"
+        },
+        "version_data" => %{
+          "default" => %{}
+        }
+      }
+
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "api" => [
+                 %{"endpoints" => "must be list"}
+               ]
+             }
+
+      # "endpoints" not list
+      new_api = %{
+        "id" => "invalid_proxy",
+        "name" => "invalid_proxy",
+        "proxy" => %{
+          "port" => 3000,
+          "target_url" => "http://localhost"
+        },
+        "version_data" => %{
+          "default" => %{"endpoints" => %{}}
+        }
+      }
+
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "api" => [
+                 %{"endpoints" => "must be list"}
+               ]
+             }
+    end
+
+    test "should return 400 when 'endpoint' doesn't have required properties 'id', 'method' and 'path'" do
+      endpoints = [%{}]
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/" => [
+                 %{"id" => "must be string"},
+                 %{"id" => "must have a length of at least 1"},
+                 %{"path" => "must be string"},
+                 %{"path" => "must have a length of at least 1"},
+                 %{"method" => "must be string"},
+                 %{"method" => "must have a length of at least 1"}
+               ]
+             }
+    end
+
+    test "should return 400 when target is set to kafka or kinesis, but topic is not" do
+      # kinesis topic not set
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo",
+          "target" => "kinesis"
+        }
+      ]
+
+      kinesis_orig_value = ProxyConfig.set("PROXY_KINESIS_REQUEST_STREAM", "")
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"kinesis_request_stream" => "must be present"},
+                 %{"topic" => "must be present"}
+               ]
+             }
+
+      ProxyConfig.restore("PROXY_KINESIS_REQUEST_STREAM", kinesis_orig_value)
+
+      # kafka topic not set
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo",
+          "target" => "kafka"
+        }
+      ]
+
+      kafka_orig_value = ProxyConfig.set("PROXY_KAFKA_REQUEST_TOPIC", "")
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"kafka_request_topic" => "must be present"},
+                 %{"topic" => "must be present"}
+               ]
+             }
+
+      ProxyConfig.restore("PROXY_KAFKA_REQUEST_TOPIC", kafka_orig_value)
+    end
+
+    test "should return 400 when schema is set, but target is not kafka or kinesis" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo",
+          "schema" => "some-avro-schema"
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"target" => "must be present"}
+               ]
+             }
+    end
+
+    test "should return 400 when secured is set, but auth_type is not jwt" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo",
+          "secured" => true
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"auth_type" => "must be one of [\"jwt\"]"}
+               ]
+             }
+    end
+
+    test "should return 400 when use_header is set, but header_name is not" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo"
+        }
+      ]
+
+      auth = %{"use_header" => true}
+      auth_type = "jwt"
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth, auth_type)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config" => [%{"header_name" => "must be present"}]
+             }
+    end
+
+    test "should return 400 when use_query is set, but query_name is not" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo"
+        }
+      ]
+
+      auth = %{"use_query" => true}
+      auth_type = "jwt"
+
+      ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth, auth_type)
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth, auth_type)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config" => [%{"query_name" => "must be present"}]
+             }
+    end
+
+    test "should return 400 when auth is set, but auth_type is not" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/foo"
+        }
+      ]
+
+      auth = %{"use_query" => true, "query_name" => "test"}
+
+      ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth)
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints, auth)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config" => [%{"auth_type" => "must be one of [\"jwt\"]"}]
+             }
+    end
+  end
+
+  describe "DELETE /v3/apis/:id" do
+    test "should delete requested API" do
+      conn = build_conn() |> delete("/v3/apis/new-service")
+      response = text_response(conn, :no_content)
+      assert response == ""
+    end
+
+    test "should return 404 if requested API doesn't exist" do
+      conn = build_conn() |> delete("/v3/apis/fake-service")
+      response = json_response(conn, 404)
+      assert response["message"] == "API with id=fake-service doesn't exists."
+    end
+
+    test "should return 404 if API exists, but is deactivated" do
+      conn = build_conn() |> delete("/v3/apis/another-service")
+      response = json_response(conn, 404)
+      assert response["message"] == "API with id=another-service doesn't exists."
+    end
+  end
+end

--- a/lib/rig_api/v3/messages.ex
+++ b/lib/rig_api/v3/messages.ex
@@ -1,0 +1,91 @@
+defmodule RigApi.V3.Messages do
+  @moduledoc "Controller for submitting (backend) events to potential (frontend) subscribers."
+  require Logger
+
+  use RigApi, :controller
+  use PhoenixSwagger
+
+  alias RIG.Sources.HTTP.Handler
+
+  @prefix "/v3"
+
+  action_fallback(RigApi.Fallback)
+
+  swagger_path :publish do
+    post(@prefix <> "/messages")
+    summary("Submit an event, to be forwarded to subscribed frontends.")
+    description("Allows you to submit a single event to RIG using a simple, \
+    synchronous call. While for production setups we recommend ingesting events \
+    asynchronously (e.g., via a Kafka topic), using this endpoint can be simple \
+    alternative during development or for low-traffic production setups.")
+
+    parameters do
+      messageBody(
+        :body,
+        Schema.ref(:CloudEvent),
+        "CloudEvent",
+        required: true
+      )
+    end
+
+    response(202, "Accepted - message queued for transport")
+    response(400, "Bad Request: Failed to parse request body :parse-error")
+  end
+
+  @doc """
+  Accepts message to be sent to front-ends.
+  """
+  def publish(%{method: "POST"} = conn, _params) do
+    Handler.handle_http_submission(conn, check_authorization?: false)
+  end
+
+  # ---
+
+  def swagger_definitions do
+    %{
+      CloudEvent:
+        swagger_schema do
+          title("CloudEvent")
+          description("The broadcasted CloudEvent according to the CloudEvents spec.")
+
+          properties do
+            id(
+              :string,
+              "ID of the event. The semantics of this string are explicitly undefined to ease \
+              the implementation of producers. Enables deduplication.",
+              required: true,
+              example: "A database commit ID"
+            )
+
+            specversion(
+              :string,
+              "The version of the CloudEvents specification which the event uses. This \
+              enables the interpretation of the context. Compliant event producers \
+              MUST use a value of 0.2 when referring to this version of the \
+              specification.",
+              required: true,
+              example: "0.2"
+            )
+
+            source(
+              :string,
+              "This describes the event producer. Often this will include information such \
+              as the type of the event source, the organization publishing the event, the \
+              process that produced the event, and some unique identifiers. The exact syntax \
+              and semantics behind the data encoded in the URI is event producer defined.",
+              required: true,
+              example: "/cloudevents/spec/pull/123"
+            )
+
+            type(
+              :string,
+              "Type of occurrence which has happened. Often this attribute is used for \
+              routing, observability, policy enforcement, etc.",
+              required: true,
+              example: "com.example.object.delete.v3"
+            )
+          end
+        end
+    }
+  end
+end

--- a/lib/rig_api/v3/messages_test.exs
+++ b/lib/rig_api/v3/messages_test.exs
@@ -1,0 +1,111 @@
+defmodule RigApi.V3.MessagesTest do
+  @moduledoc false
+  use RigApi.ConnCase, async: true
+
+  alias Plug.Conn.Status
+
+  import Mox
+  setup :verify_on_exit!
+
+  @cloud_event_json ~s({"cloudEventsVersion":"0.1","source":"test","eventType":"test.event","eventID":"1"})
+  @non_cloud_event ~s({"source":"test","eventType":"test.event","eventID":"1"})
+
+  setup do
+    # TODO that mock doesn't work - the request goes to the real Filter :(
+    Rig.EventFilterMock
+    |> stub(:forward_event, fn ev -> send(self(), {:cloud_event_sent, ev}) end)
+
+    :ok
+  end
+
+  # test "application/x-www-form-urlencoded is not supported"
+  # test "text/plain is not supported"
+
+  describe "Structured mode" do
+    test "is supported for content-type application/cloudevents+json." do
+      conn =
+        new_conn("application/cloudevents+json;charset=utf-8")
+        |> post("/v3/messages", @cloud_event_json)
+
+      assert conn.status == Status.code(:accepted)
+      # TODO mock doesn't work..
+      # assert_receive {:cloud_event_sent, _}
+    end
+
+    test "ignores any ce-* headers." do
+      conn =
+        new_conn("application/cloudevents+json;charset=utf-8")
+        |> put_req_header("ce-specversion", "illegal")
+        |> put_req_header("ce-type", "")
+        |> put_req_header("ce-source", "")
+        |> put_req_header("ce-id", "")
+        |> post("/v3/messages", @cloud_event_json)
+
+      assert conn.status == Status.code(:accepted), "#{conn.status} #{inspect(conn.resp_body)}"
+      # TODO mock doesn't work..
+      # assert_receive {:cloud_event_sent, @cloud_event_json}
+    end
+
+    test "rejects events that don't follow the CloudEvents format." do
+      conn =
+        new_conn("application/cloudevents+json;charset=utf-8")
+        |> post("/v3/messages", @non_cloud_event)
+
+      assert conn.status == Status.code(:bad_request)
+      refute_received {:cloud_event_sent, _}
+    end
+  end
+
+  describe "Binary content mode" do
+    test "is supported for content-type application/json." do
+      event = %{
+        "specversion" => "0.2",
+        "type" => "my-event-type",
+        "source" => "#{__MODULE__}/binary/json",
+        "id" => "1",
+        "contenttype" => "application/json;charset=utf-8",
+        "data" => ~S({"some": "value"})
+      }
+
+      conn =
+        new_conn(event["contenttype"])
+        |> put_req_header("ce-specversion", event["specversion"])
+        |> put_req_header("ce-type", event["type"])
+        |> put_req_header("ce-source", event["source"])
+        |> put_req_header("ce-id", event["id"])
+        |> post("/v3/messages", event["data"])
+
+      assert conn.status == Status.code(:accepted)
+      # TODO mock doesn't work..
+      # assert_receive {:cloud_event_sent, event}
+    end
+
+    test "is not supported for any other content-type." do
+      event = %{
+        "specversion" => "0.2",
+        "type" => "my-event-type",
+        "source" => "#{__MODULE__}/binary/text",
+        "id" => "1",
+        "contenttype" => "text/plain",
+        "data" => "This is a human-readable representation.."
+      }
+
+      conn =
+        new_conn(event["contenttype"])
+        |> put_req_header("ce-specversion", event["specversion"])
+        |> put_req_header("ce-type", event["type"])
+        |> put_req_header("ce-source", event["source"])
+        |> put_req_header("ce-id", event["id"])
+        |> post("/v3/messages", event["data"])
+
+      assert conn.status == Status.code(:accepted)
+      # TODO mock doesn't work..
+      # assert_receive {:cloud_event_sent, event}
+    end
+  end
+
+  defp new_conn(content_type) do
+    build_conn()
+    |> put_req_header("content-type", content_type)
+  end
+end

--- a/lib/rig_api/v3/responses.ex
+++ b/lib/rig_api/v3/responses.ex
@@ -1,14 +1,13 @@
-defmodule RigApi.V2.Responses do
+defmodule RigApi.V3.Responses do
   @moduledoc "Controller for submitting (backend) responses to asynchronous (frontend) requests."
   require Logger
 
   use RigApi, :controller
   use PhoenixSwagger
 
-  alias Rig.Connection.Codec
-  alias RigCloudEvents.CloudEvent
+  alias RigInboundGateway.ApiProxy.ResponseFromParser
 
-  @prefix "/v2"
+  @prefix "/v3"
 
   action_fallback(RigApi.Fallback)
 
@@ -33,20 +32,19 @@ defmodule RigApi.V2.Responses do
 
   @doc """
   Accepts message to be sent to correlated HTTP process.
+
   Note that body has to contain following field `"rig": { "correlation": "_id_" }`.
   """
-  def create(conn, message) do
-    with {:ok, cloud_event} <- CloudEvent.parse(message),
-         {:ok, rig_metadata} <- Map.fetch(message, "rig"),
-         {:ok, correlation_id} <- Map.fetch(rig_metadata, "correlation"),
-         {:ok, deserialized_pid} <- Codec.deserialize(correlation_id) do
-      Logger.debug(fn ->
-        "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
-      end)
+  def create(%{req_headers: req_headers} = conn, message) do
+    case ResponseFromParser.parse(req_headers, message) do
+      {deserialized_pid, response_code, response} ->
+        Logger.debug(fn ->
+          "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
+        end)
 
-      send(deserialized_pid, {:response_received, cloud_event.json})
-      send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
-    else
+        send(deserialized_pid, {:response_received, response, response_code})
+        send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
+
       err ->
         Logger.warn(fn -> "Parse error #{inspect(err)} for #{inspect(message)}" end)
 
@@ -97,7 +95,7 @@ defmodule RigApi.V2.Responses do
               "Type of occurrence which has happened. Often this attribute is used for \
               routing, observability, policy enforcement, etc.",
               required: true,
-              example: "com.example.object.delete.v2"
+              example: "com.example.object.delete.v3"
             )
 
             rig(

--- a/lib/rig_api/v3/responses.ex
+++ b/lib/rig_api/v3/responses.ex
@@ -37,12 +37,12 @@ defmodule RigApi.V3.Responses do
   """
   def create(%{req_headers: req_headers} = conn, message) do
     case ResponseFromParser.parse(req_headers, message) do
-      {deserialized_pid, response_code, response} ->
+      {deserialized_pid, response_code, response, extra_headers} ->
         Logger.debug(fn ->
           "HTTP response via internal HTTP to #{inspect(deserialized_pid)}: #{inspect(message)}"
         end)
 
-        send(deserialized_pid, {:response_received, response, response_code})
+        send(deserialized_pid, {:response_received, response, response_code, extra_headers})
         send_resp(conn, :accepted, "message sent to correlated reverse proxy request")
 
       err ->

--- a/lib/rig_api/v3/session_blacklist.ex
+++ b/lib/rig_api/v3/session_blacklist.ex
@@ -1,0 +1,190 @@
+defmodule RigApi.V3.SessionBlacklist do
+  @moduledoc """
+  Controller that allows blocking "sessions" for a specific period of time.
+
+  What a session is depends on your business context and the `JWT_SESSION_FIELD`
+  setting. For example, a session ID could be a random ID assigned to a token upon
+  login, or the id of the user the token belongs to.
+  """
+  use RigApi, :controller
+  use PhoenixSwagger
+  require Logger
+
+  alias RIG.Session
+
+  @prefix "/v3"
+  @cors_origins "*"
+
+  # ---
+
+  @doc false
+  def handle_preflight(%{method: "OPTIONS"} = conn, _params) do
+    conn
+    |> with_allow_origin()
+    |> put_resp_header("access-control-allow-methods", "POST")
+    |> put_resp_header("access-control-allow-headers", "content-type")
+    |> send_resp(:no_content, "")
+  end
+
+  # ---
+
+  defp with_allow_origin(conn) do
+    put_resp_header(conn, "access-control-allow-origin", @cors_origins)
+  end
+
+  # ---
+
+  swagger_path :check_status do
+    get(@prefix <> "/session-blacklist/{sessionId}")
+    summary("Check whether a given session is currently blacklisted.")
+
+    parameters do
+      sessionId(:path, :string, "The JWT ID (jti) claim that identifies the session.",
+        required: true
+      )
+    end
+
+    response(200, "This session is currently blacklisted.")
+    response(404, "There is no entry in the blacklist that matches this session name.")
+  end
+
+  @doc "Check blacklist status for a specific session id."
+  def check_status(%{method: "GET"} = conn, %{"session_id" => session_id}) do
+    if Session.blacklisted?(session_id) do
+      conn
+      |> put_resp_header("content-type", "application/json; charset=utf-8")
+      |> send_resp(:ok, "{}")
+    else
+      conn
+      |> send_resp(:not_found, "Not found.")
+    end
+  end
+
+  # ---
+
+  swagger_path :blacklist_session do
+    post(@prefix <> "/session-blacklist")
+    summary("Add a session to the session blacklist.")
+
+    description("""
+    When successful, the given session is no longer considered valid, regardless of \
+    the token's expiration timestamp. This has the following consequences:
+
+    - Any existing connection related to the session is terminated immediately.
+    - The related authorization token is no longer valid when a client establishes a connection.
+    - The related authorization token is no longer valid when a client creates a subscription.
+    """)
+
+    parameters do
+      sessionBlacklist(
+        :body,
+        Schema.ref(:SessionBlacklistRequest),
+        "The details for blacklisting a session",
+        required: true
+      )
+    end
+
+    response(
+      201,
+      "The session is now blacklisted. The location header points to the newly created entry."
+    )
+
+    response(400, "Bad request.")
+  end
+
+  @doc "Plug action to add a session id to the session blacklist."
+  def blacklist_session(%{method: "POST"} = conn, _params) do
+    conn = with_allow_origin(conn)
+
+    case parse(conn.body_params) do
+      {:error, reason} ->
+        send_resp(conn, :bad_request, reason)
+
+      {:ok, %{session_id: session_id, ttl_s: ttl_s}} ->
+        Session.blacklist(session_id, ttl_s)
+
+        location = Path.join(conn.request_path, "/#{session_id}")
+
+        conn
+        |> put_resp_header("location", location)
+        |> put_resp_header("content-type", "application/json; charset=utf-8")
+        |> send_resp(:created, "{}")
+    end
+  end
+
+  # ---
+
+  defp parse(body) do
+    Result.ok(%{})
+    |> Result.and_then(&parse_and_add_session_id(&1, body))
+    |> Result.and_then(&parse_and_add_ttl_s(&1, body))
+  end
+
+  # ---
+
+  defp parse_and_add_session_id(into, from) do
+    case Map.fetch(from, "sessionId") do
+      {:ok, value} when byte_size(value) > 0 -> {:ok, Map.merge(into, %{session_id: value})}
+      {:ok, value} -> {:error, "Expected non-empty string, got #{inspect(value)}"}
+      :error -> {:error, "Missing value for \"sessionId\""}
+    end
+  end
+
+  # ---
+
+  defp parse_and_add_ttl_s(into, from) do
+    case Map.fetch(from, "validityInSeconds") do
+      {:ok, value} when is_number(value) and value > 0 ->
+        {:ok, Map.merge(into, %{ttl_s: value})}
+
+      {:ok, value} when byte_size(value) > 0 ->
+        case Integer.parse(value) do
+          {value, ""} -> parse_and_add_ttl_s(into, Map.put(from, "validityInSeconds", value))
+          _ -> {:error, "Expected a number, got #{inspect(value)}"}
+        end
+
+      {:ok, value} ->
+        {:error, "Expected a positive number, got #{inspect(value)}"}
+
+      :error ->
+        {:error, "Missing value for \"validityInSeconds\""}
+    end
+  end
+
+  # ---
+
+  def swagger_definitions do
+    %{
+      SessionBlacklistRequest:
+        swagger_schema do
+          title("Session Blacklist Request")
+
+          properties do
+            sessionId(
+              :string,
+              """
+              The JWT claim that defines a "session". For details see the \
+              `JWT_SESSION_FIELD` setting in the operator's guide \
+              (https://accenture.github.io/reactive-interaction-gateway/docs/rig-ops-guide.html).
+              """,
+              required: true
+            )
+
+            validityInSeconds(
+              :number,
+              """
+              Defines how long the sessionId will stay on the blacklist. \
+              Typically set to the JWT's remaining lifetime.
+              """,
+              required: true
+            )
+          end
+
+          example(%{
+            sessionId: "SomeSessionID123",
+            validityInSeconds: 60
+          })
+        end
+    }
+  end
+end

--- a/lib/rig_api/v3/session_blacklist_test.exs
+++ b/lib/rig_api/v3/session_blacklist_test.exs
@@ -1,0 +1,29 @@
+defmodule RigApi.V3.SessionBlacklistTest do
+  @moduledoc false
+  use RigApi.ConnCase, async: true
+
+  alias UUID
+
+  @prefix "/v3"
+
+  test "After blacklisting a session ID, the location header points to the blacklist entry." do
+    session_id = UUID.uuid4()
+
+    body = Jason.encode!(%{validityInSeconds: 123, sessionId: session_id})
+
+    conn =
+      build_conn()
+      |> put_req_header("content-type", "application/json")
+      |> post(@prefix <> "/session-blacklist", body)
+
+    # Assert 201 and json response:
+    json_response(conn, 201)
+
+    [entry_location] = get_resp_header(conn, "location")
+
+    # We know it's an absolute-path reference, so we can use build_conn to fetch it.
+    build_conn()
+    |> get(entry_location)
+    |> json_response(200)
+  end
+end

--- a/lib/rig_inbound_gateway/api_proxy/handler/http.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/http.ex
@@ -116,8 +116,8 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
         |> with_cors()
         |> Tracing.Plug.put_resp_header(Tracing.context())
         |> Conn.put_resp_content_type("application/json")
-        |> Map.update!(:resp_headers, fn existing_header ->
-          existing_header ++ Map.to_list(response_headers)
+        |> Map.update!(:resp_headers, fn existing_headers ->
+          existing_headers ++ Map.to_list(response_headers)
         end)
         |> Conn.send_resp(response_code, response)
     after

--- a/lib/rig_inbound_gateway/api_proxy/handler/http.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/http.ex
@@ -103,7 +103,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
       end
 
     receive do
-      {:response_received, response, response_code, response_headers} ->
+      {:response_received, response, response_code} ->
         ProxyMetrics.count_proxy_request(
           conn.method,
           conn.request_path,
@@ -116,9 +116,6 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
         |> with_cors()
         |> Tracing.Plug.put_resp_header(Tracing.context())
         |> Conn.put_resp_content_type("application/json")
-        |> Map.update!(:resp_headers, fn existing_headers ->
-          existing_headers ++ Map.to_list(response_headers)
-        end)
         |> Conn.send_resp(response_code, response)
     after
       response_timeout ->

--- a/lib/rig_inbound_gateway/api_proxy/handler/http.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/http.ex
@@ -103,7 +103,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
       end
 
     receive do
-      {:response_received, response} ->
+      {:response_received, response, response_code} ->
         ProxyMetrics.count_proxy_request(
           conn.method,
           conn.request_path,
@@ -116,7 +116,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
         |> with_cors()
         |> Tracing.Plug.put_resp_header(Tracing.context())
         |> Conn.put_resp_content_type("application/json")
-        |> Conn.send_resp(:ok, response)
+        |> Conn.send_resp(response_code, response)
     after
       response_timeout ->
         ProxyMetrics.count_proxy_request(

--- a/lib/rig_inbound_gateway/api_proxy/handler/http.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/http.ex
@@ -103,7 +103,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
       end
 
     receive do
-      {:response_received, response, response_code} ->
+      {:response_received, response, response_code, extra_headers} ->
         ProxyMetrics.count_proxy_request(
           conn.method,
           conn.request_path,
@@ -115,6 +115,9 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
         conn
         |> with_cors()
         |> Tracing.Plug.put_resp_header(Tracing.context())
+        |> Map.update!(:resp_headers, fn existing_headers ->
+          existing_headers ++ Map.to_list(extra_headers)
+        end)
         |> Conn.put_resp_content_type("application/json")
         |> Conn.send_resp(response_code, response)
     after

--- a/lib/rig_inbound_gateway/api_proxy/handler/http.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/http.ex
@@ -103,7 +103,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
       end
 
     receive do
-      {:response_received, response, response_code} ->
+      {:response_received, response, response_code, response_headers} ->
         ProxyMetrics.count_proxy_request(
           conn.method,
           conn.request_path,
@@ -116,6 +116,9 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
         |> with_cors()
         |> Tracing.Plug.put_resp_header(Tracing.context())
         |> Conn.put_resp_content_type("application/json")
+        |> Map.update!(:resp_headers, fn existing_header ->
+          existing_header ++ Map.to_list(response_headers)
+        end)
         |> Conn.send_resp(response_code, response)
     after
       response_timeout ->

--- a/lib/rig_inbound_gateway/api_proxy/handler/http.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/http.ex
@@ -118,7 +118,6 @@ defmodule RigInboundGateway.ApiProxy.Handler.Http do
         |> Map.update!(:resp_headers, fn existing_headers ->
           existing_headers ++ Map.to_list(extra_headers)
         end)
-        |> Conn.put_resp_content_type("application/json")
         |> Conn.send_resp(response_code, response)
     after
       response_timeout ->

--- a/lib/rig_inbound_gateway/api_proxy/handler/kafka.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/kafka.ex
@@ -271,7 +271,6 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kafka do
         |> Map.update!(:resp_headers, fn existing_headers ->
           existing_headers ++ Map.to_list(extra_headers)
         end)
-        |> Conn.put_resp_content_type("application/json")
         |> Conn.send_resp(response_code, response)
     after
       conf.response_timeout ->

--- a/lib/rig_inbound_gateway/api_proxy/handler/kafka.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/kafka.ex
@@ -43,14 +43,14 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kafka do
           | {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()},
              any()}
   def kafka_handler(message, headers) do
-    with {deserialized_pid, response_code, response} <-
-           ResponseFromParser.parse(headers, message) do
-      Logger.debug(fn ->
-        "HTTP response via Kafka to #{inspect(deserialized_pid)}: #{inspect(message)}"
-      end)
+    case ResponseFromParser.parse(headers, message) do
+      {deserialized_pid, response_code, response} ->
+        Logger.debug(fn ->
+          "HTTP response via Kafka to #{inspect(deserialized_pid)}: #{inspect(message)}"
+        end)
 
-      send(deserialized_pid, {:response_received, response, response_code})
-    else
+        send(deserialized_pid, {:response_received, response, response_code})
+
       err ->
         Logger.warn(fn -> "Parse error #{inspect(err)} for #{inspect(message)}" end)
         :ignore

--- a/lib/rig_inbound_gateway/api_proxy/handler/kinesis.ex
+++ b/lib/rig_inbound_gateway/api_proxy/handler/kinesis.ex
@@ -228,7 +228,7 @@ defmodule RigInboundGateway.ApiProxy.Handler.Kinesis do
     Conn.send_resp(conn, :bad_request, response)
   end
 
-  # ---
+  # --- Not used at the moment
 
   defp wait_for_response(conn, response_from) do
     conf = config()

--- a/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
+++ b/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
@@ -1,0 +1,103 @@
+defmodule RigInboundGateway.ApiProxy.ResponseFromParser do
+  @moduledoc """
+  Handles parsing of messages coming from different sources (e.g. Kafka)
+
+  """
+
+  require Logger
+
+  use Rig.Config, [:schema_registry_host]
+
+  alias Rig.Connection.Codec
+  alias RigKafka.Avro
+
+  @default_response_code 200
+
+  # ---
+
+  @spec parse([{String.t(), String.t()}, ...], map()) ::
+          {pid, pos_integer(), any(), map()} | String.t()
+  # structured
+  def parse(
+        _headers,
+        %{
+          "body" => body,
+          "rig" => rig_metadata
+        } = message
+      ) do
+    with {:ok, correlation_id} <- Map.fetch(rig_metadata, "correlation"),
+         {:ok, deserialized_pid} <- Codec.deserialize(correlation_id),
+         raw_response_code <- Map.get(rig_metadata, "response_code", @default_response_code),
+         # convert status code to int if needed, HTTP headers can't have number as a value
+         {response_code, _} <- to_int(raw_response_code),
+         response_headers <- Map.get(message, "headers", %{}),
+         response_body <- try_encode(body) do
+      Logger.debug(fn ->
+        "Parsed structured HTTP response: body=#{inspect(response_body)}, headers=#{
+          inspect(response_headers)
+        }, code=#{inspect(response_code)}"
+      end)
+
+      {deserialized_pid, response_code, response_body, response_headers}
+    else
+      err -> err
+    end
+  end
+
+  # binary
+  def parse(
+        headers,
+        message
+      ) do
+    with headers_map <- Enum.into(headers, %{}),
+         {:ok, correlation_id} <- Map.fetch(headers_map, "rig-correlation"),
+         {:ok, deserialized_pid} <- Codec.deserialize(correlation_id),
+         raw_response_code <- Map.get(headers_map, "rig-response-code", @default_response_code),
+         # convert status code to int if needed, HTTP headers can't have number as a value
+         {response_code, _} <- to_int(raw_response_code),
+         response_body <- try_encode(message) do
+      Logger.debug(fn ->
+        "Parsed binary HTTP response: body=#{inspect(message)}, code=#{inspect(response_code)}"
+      end)
+
+      {deserialized_pid, response_code, response_body, %{}}
+    else
+      err -> err
+    end
+  end
+
+  # ---
+
+  @spec try_decode_message(<<_::3>> | String.t()) :: String.t() | map()
+  def try_decode_message(<<0::8, _id::32, _body::binary>> = message),
+    do: Avro.decode(message, config().schema_registry_host)
+
+  def try_decode_message(message) when is_binary(message) do
+    case Jason.decode(message) do
+      {:ok, val_map} ->
+        val_map
+
+      _ ->
+        message
+    end
+  end
+
+  # ---
+
+  defp try_encode(message) when is_binary(message), do: message
+
+  defp try_encode(message) do
+    case Jason.encode(message) do
+      {:ok, val_map} ->
+        val_map
+
+      _ ->
+        message
+    end
+  end
+
+  # ---
+
+  defp to_int(value) when is_integer(value), do: {value, nil}
+  defp to_int(value), do: Integer.parse(value)
+end

--- a/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
+++ b/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
@@ -24,7 +24,7 @@ defmodule RigInboundGateway.ApiProxy.ResponseFromParser do
          # forward extra haeders such as content-type
          extra_headers <- Map.drop(headers_map, ["rig-correlation", "rig-response-code"]),
          # convert status code to int if needed, HTTP headers can't have number as a value
-         response_code <- to_int(raw_response_code),
+         {:ok, response_code} <- to_int(raw_response_code),
          response_body <- try_encode(message) do
       Logger.debug(fn ->
         "Parsed binary HTTP response: body=#{inspect(response_body)}, code=#{
@@ -54,10 +54,10 @@ defmodule RigInboundGateway.ApiProxy.ResponseFromParser do
 
   # ---
 
-  defp to_int(value) when is_integer(value), do: value
+  defp to_int(value) when is_integer(value), do: {:ok, value}
 
   defp to_int(string) when is_binary(string) do
-    String.to_integer(string)
+    {:ok, String.to_integer(string)}
   rescue
     ArgumentError -> {:error, {:not_an_integer, string}}
   end

--- a/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
+++ b/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
@@ -51,5 +51,9 @@ defmodule RigInboundGateway.ApiProxy.ResponseFromParser do
   # ---
 
   defp to_int(value) when is_integer(value), do: value
-  defp to_int(value) when is_binary(value), do: String.to_integer(value)
+  defp to_int(string) when is_binary(string) do
+    String.to_integer(string)
+  rescue
+    ArgumentError -> {:error, {:not_an_integer, string}}
+  end
 end

--- a/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
+++ b/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
@@ -9,42 +9,12 @@ defmodule RigInboundGateway.ApiProxy.ResponseFromParser do
   use Rig.Config, [:schema_registry_host]
 
   alias Rig.Connection.Codec
-  alias RigKafka.Avro
-
-  @default_response_code 200
 
   # ---
 
   @spec parse([{String.t(), String.t()}, ...], map()) ::
-          {pid, pos_integer(), any(), map()} | String.t()
-  # structured
-  def parse(
-        _headers,
-        %{
-          "body" => body,
-          "rig" => rig_metadata
-        } = message
-      ) do
-    with {:ok, correlation_id} <- Map.fetch(rig_metadata, "correlation"),
-         {:ok, deserialized_pid} <- Codec.deserialize(correlation_id),
-         raw_response_code <- Map.get(rig_metadata, "response_code", @default_response_code),
-         # convert status code to int if needed, HTTP headers can't have number as a value
-         {response_code, _} <- to_int(raw_response_code),
-         response_headers <- Map.get(message, "headers", %{}),
-         response_body <- try_encode(body) do
-      Logger.debug(fn ->
-        "Parsed structured HTTP response: body=#{inspect(response_body)}, headers=#{
-          inspect(response_headers)
-        }, code=#{inspect(response_code)}"
-      end)
+          {pid, pos_integer(), any()} | String.t()
 
-      {deserialized_pid, response_code, response_body, response_headers}
-    else
-      err -> err
-    end
-  end
-
-  # binary
   def parse(
         headers,
         message
@@ -52,33 +22,17 @@ defmodule RigInboundGateway.ApiProxy.ResponseFromParser do
     with headers_map <- Enum.into(headers, %{}),
          {:ok, correlation_id} <- Map.fetch(headers_map, "rig-correlation"),
          {:ok, deserialized_pid} <- Codec.deserialize(correlation_id),
-         raw_response_code <- Map.get(headers_map, "rig-response-code", @default_response_code),
+         {:ok, raw_response_code} <- Map.fetch(headers_map, "rig-response-code"),
          # convert status code to int if needed, HTTP headers can't have number as a value
-         {response_code, _} <- to_int(raw_response_code),
+         response_code <- to_int(raw_response_code),
          response_body <- try_encode(message) do
       Logger.debug(fn ->
-        "Parsed binary HTTP response: body=#{inspect(message)}, code=#{inspect(response_code)}"
+        "Parsed binary HTTP response: body=#{inspect(response_body)}, code=#{inspect(response_code)}"
       end)
 
-      {deserialized_pid, response_code, response_body, %{}}
+      {deserialized_pid, response_code, response_body}
     else
       err -> err
-    end
-  end
-
-  # ---
-
-  @spec try_decode_message(<<_::3>> | String.t()) :: String.t() | map()
-  def try_decode_message(<<0::8, _id::32, _body::binary>> = message),
-    do: Avro.decode(message, config().schema_registry_host)
-
-  def try_decode_message(message) when is_binary(message) do
-    case Jason.decode(message) do
-      {:ok, val_map} ->
-        val_map
-
-      _ ->
-        message
     end
   end
 
@@ -98,6 +52,6 @@ defmodule RigInboundGateway.ApiProxy.ResponseFromParser do
 
   # ---
 
-  defp to_int(value) when is_integer(value), do: {value, nil}
-  defp to_int(value), do: Integer.parse(value)
+  defp to_int(value) when is_integer(value), do: value
+  defp to_int(value) when is_binary(value), do: String.to_integer(value)
 end

--- a/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
+++ b/lib/rig_inbound_gateway/api_proxy/response_from_parser.ex
@@ -6,8 +6,6 @@ defmodule RigInboundGateway.ApiProxy.ResponseFromParser do
 
   require Logger
 
-  use Rig.Config, [:schema_registry_host]
-
   alias Rig.Connection.Codec
 
   # ---

--- a/lib/rig_kafka/client.ex
+++ b/lib/rig_kafka/client.ex
@@ -326,9 +326,9 @@ defmodule RigKafka.Client do
               {data, additional_headers} = Map.pop(plaintext_map, "data", %{})
 
               prefixed_headers =
-                headers
-                |> Enum.concat(additional_headers)
+                additional_headers
                 |> Serializer.add_prefix()
+                |> Enum.concat(headers)
                 |> Enum.concat([{"content-type", "avro/binary"}])
 
               {prefixed_headers,

--- a/test/rig_tests/proxy/publish_to_event_stream/kafka_test.exs
+++ b/test/rig_tests/proxy/publish_to_event_stream/kafka_test.exs
@@ -75,8 +75,6 @@ defmodule RigTests.Proxy.PublishToEventStream.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "OPTIONS",
                 path: endpoint_path,
                 target: "kafka"
@@ -134,8 +132,6 @@ defmodule RigTests.Proxy.PublishToEventStream.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "POST",
                 path: endpoint_path,
                 target: "kafka",
@@ -252,8 +248,6 @@ defmodule RigTests.Proxy.PublishToEventStream.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "POST",
                 path: endpoint_path,
                 target: "kafka",
@@ -371,8 +365,6 @@ defmodule RigTests.Proxy.PublishToEventStream.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "POST",
                 path: endpoint_path,
                 target: "kafka"
@@ -488,8 +480,6 @@ defmodule RigTests.Proxy.PublishToEventStream.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "POST",
                 path: endpoint_path,
                 target: "kafka"

--- a/test/rig_tests/proxy/response_from/async_http_test.exs
+++ b/test/rig_tests/proxy/response_from/async_http_test.exs
@@ -40,7 +40,7 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
       message =
         Jason.encode!(%{
           rig: %{correlation: correlation_id},
-          body: Jason.encode!(async_response)
+          body: async_response
         })
 
       build_conn()
@@ -167,7 +167,7 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
       message =
         Jason.encode!(%{
           rig: %{correlation: correlation_id, response_code: 201},
-          body: Jason.encode!(async_response)
+          body: async_response
         })
 
       build_conn()
@@ -233,11 +233,9 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
       message =
         Jason.encode!(%{
           rig: %{correlation: correlation_id, response_code: 201},
-          body: Jason.encode!(async_response),
+          body: async_response,
           headers: %{foo: "bar"}
         })
-
-      IO.inspect(message, label: "message")
 
       build_conn()
       |> put_req_header("content-type", "application/json;charset=utf-8")

--- a/test/rig_tests/proxy/response_from/async_http_test.exs
+++ b/test/rig_tests/proxy/response_from/async_http_test.exs
@@ -77,13 +77,17 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
 
     # The client calls the proxy endpoint:
     request_url = rig_proxy_url <> endpoint_path
-    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+
+    %HTTPoison.Response{status_code: res_status, body: res_body, headers: headers} =
+      HTTPoison.get!(request_url)
 
     # Now we can assert that...
     # ...the fake backend service has been called:
     assert FakeServer.hits() == 1
     # ...the connection is closed and the status is OK:
     assert res_status == 201
+    # ...extra headers are present
+    assert Enum.member?(headers, {"content-type", "application/json; charset=utf-8"})
     # ...but the client got the response sent to the HTTP internal endpoint:
     assert Jason.decode!(res_body) == async_response
   end

--- a/test/rig_tests/proxy/response_from/async_http_test.exs
+++ b/test/rig_tests/proxy/response_from/async_http_test.exs
@@ -63,7 +63,6 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
                 method: "GET",
                 path: endpoint_path,
                 response_from: "http_async"
@@ -124,7 +123,6 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
                 method: "GET",
                 path: endpoint_path,
                 response_from: "http_async"
@@ -190,7 +188,6 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
                 method: "GET",
                 path: endpoint_path,
                 response_from: "http_async"
@@ -257,7 +254,6 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
                 method: "GET",
                 path: endpoint_path,
                 response_from: "http_async"
@@ -322,7 +318,6 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
                 method: "GET",
                 path: endpoint_path,
                 response_from: "http_async"
@@ -348,6 +343,71 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     assert FakeServer.hits() == 1
     # ...the connection is closed and the status is OK:
     assert res_status == 201
+    # ...but the client got the response sent to the HTTP internal endpoint:
+    assert Jason.decode!(res_body) == async_response
+  end
+
+  test_with_server "Given response_from (/v1) is set to http_async, the http response is taken from the internal HTTP endpoint." do
+    test_name = "proxy-http-response-from-http-internal-v1"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"this response" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      message =
+        Jason.encode!(%{
+          rig: %{correlation: correlation_id},
+          body: async_response
+        })
+
+      build_conn()
+      |> put_req_header("content-type", "application/json;charset=utf-8")
+      |> post("/v1/responses", message)
+
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v1/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                method: "GET",
+                path: endpoint_path,
+                response_from: "http_async"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
+    # ...the connection is closed and the status is OK:
+    assert res_status == 200
     # ...but the client got the response sent to the HTTP internal endpoint:
     assert Jason.decode!(res_body) == async_response
   end

--- a/test/rig_tests/proxy/response_from/async_http_test.exs
+++ b/test/rig_tests/proxy/response_from/async_http_test.exs
@@ -98,4 +98,146 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     # ...but the client got the response sent to the HTTP internal endpoint:
     assert Jason.decode!(res_body)["data"] == async_response
   end
+
+  test_with_server "Given response_from is set to http_async, the custom http response code - 201 - is taken from the internal HTTP endpoint." do
+    test_name = "proxy-http-response-from-http-internal-status-code"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"this response" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      event =
+        Jason.encode!(%{
+          specversion: "0.2",
+          type: "rig.async-response",
+          source: "fake-service",
+          id: "1",
+          rig: %{correlation: correlation_id, response_code: 201},
+          data: async_response
+        })
+
+      build_conn()
+      |> put_req_header("content-type", "application/json;charset=utf-8")
+      |> post("/v2/responses", event)
+
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                type: "http",
+                method: "GET",
+                path: endpoint_path,
+                response_from: "http_async"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
+    # ...the connection is closed and the status is OK:
+    assert res_status == 201
+    # ...the client never saw the http response:
+    assert Jason.decode!(res_body) != sync_response
+    # ...but the client got the response sent to the HTTP internal endpoint:
+    assert Jason.decode!(res_body)["data"] == async_response
+  end
+
+  test_with_server "Given response_from is set to http_async and response is in binary mode, the custom http response code - 201 - is taken from the internal HTTP endpoint." do
+    test_name = "proxy-http-response-from-http-internal-binary-status-code"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"this response" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      event = Jason.encode!(async_response)
+
+      build_conn()
+      |> put_req_header("content-type", "application/json;charset=utf-8")
+      |> put_req_header("ce-specversion", "0.2")
+      |> put_req_header("ce-type", "rig.async-response")
+      |> put_req_header("ce-source", "fake-service")
+      |> put_req_header("ce-id", "1")
+      |> put_req_header(
+        "ce-rig",
+        Jason.encode!(%{correlation: correlation_id, response_code: 201})
+      )
+      |> post("/v2/responses", event)
+
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                type: "http",
+                method: "GET",
+                path: endpoint_path,
+                response_from: "http_async"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
+    # ...the connection is closed and the status is OK:
+    assert res_status == 201
+    # ...but the client got the response sent to the HTTP internal endpoint:
+    assert Jason.decode!(res_body) == async_response
+  end
 end

--- a/test/rig_tests/proxy/response_from/async_http_test.exs
+++ b/test/rig_tests/proxy/response_from/async_http_test.exs
@@ -37,19 +37,15 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     async_response = %{"message" => "this is the async response that reaches the client instead"}
 
     route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
-      event =
+      message =
         Jason.encode!(%{
-          specversion: "0.2",
-          type: "rig.async-response",
-          source: "fake-service",
-          id: "1",
           rig: %{correlation: correlation_id},
-          data: async_response
+          body: Jason.encode!(async_response)
         })
 
       build_conn()
       |> put_req_header("content-type", "application/json;charset=utf-8")
-      |> post("/v2/responses", event)
+      |> post("/v2/responses", message)
 
       Response.ok!(sync_response, %{"content-type" => "application/json"})
     end)
@@ -93,10 +89,69 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     assert FakeServer.hits() == 1
     # ...the connection is closed and the status is OK:
     assert res_status == 200
-    # ...the client never saw the http response:
-    assert Jason.decode!(res_body) != sync_response
     # ...but the client got the response sent to the HTTP internal endpoint:
-    assert Jason.decode!(res_body)["data"] == async_response
+    assert Jason.decode!(res_body) == async_response
+  end
+
+  test_with_server "Given response_from is set to http_async and response is in binary mode, the http response should include only body content." do
+    test_name = "proxy-http-response-from-http-internal-binary"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"this response" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      build_conn()
+      |> put_req_header("rig-correlation", correlation_id)
+      |> put_req_header("content-type", "application/json;charset=utf-8")
+      |> post("/v2/responses", Jason.encode!(async_response))
+
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                type: "http",
+                method: "GET",
+                path: endpoint_path,
+                response_from: "http_async"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
+    # ...the connection is closed and the status is OK:
+    assert res_status == 200
+    # ...but the client got the response sent to the HTTP internal endpoint:
+    assert Jason.decode!(res_body) == async_response
   end
 
   test_with_server "Given response_from is set to http_async, the custom http response code - 201 - is taken from the internal HTTP endpoint." do
@@ -109,19 +164,15 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     async_response = %{"message" => "this is the async response that reaches the client instead"}
 
     route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
-      event =
+      message =
         Jason.encode!(%{
-          specversion: "0.2",
-          type: "rig.async-response",
-          source: "fake-service",
-          id: "1",
           rig: %{correlation: correlation_id, response_code: 201},
-          data: async_response
+          body: Jason.encode!(async_response)
         })
 
       build_conn()
       |> put_req_header("content-type", "application/json;charset=utf-8")
-      |> post("/v2/responses", event)
+      |> post("/v2/responses", message)
 
       Response.ok!(sync_response, %{"content-type" => "application/json"})
     end)
@@ -165,10 +216,80 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     assert FakeServer.hits() == 1
     # ...the connection is closed and the status is OK:
     assert res_status == 201
-    # ...the client never saw the http response:
-    assert Jason.decode!(res_body) != sync_response
     # ...but the client got the response sent to the HTTP internal endpoint:
-    assert Jason.decode!(res_body)["data"] == async_response
+    assert Jason.decode!(res_body) == async_response
+  end
+
+  test_with_server "Given response_from is set to http_async, the provided headers are taken from the internal HTTP endpoint." do
+    test_name = "proxy-http-response-from-http-internal-headers"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"this response" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      message =
+        Jason.encode!(%{
+          rig: %{correlation: correlation_id, response_code: 201},
+          body: Jason.encode!(async_response),
+          headers: %{foo: "bar"}
+        })
+
+      IO.inspect(message, label: "message")
+
+      build_conn()
+      |> put_req_header("content-type", "application/json;charset=utf-8")
+      |> post("/v2/responses", message)
+
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                type: "http",
+                method: "GET",
+                path: endpoint_path,
+                response_from: "http_async"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+
+    %HTTPoison.Response{status_code: res_status, body: res_body, headers: res_headers} =
+      HTTPoison.get!(request_url)
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
+    # ...the connection is closed and the status is OK:
+    assert res_status == 201
+    # ...but the client got the response sent to the HTTP internal endpoint:
+    assert Jason.decode!(res_body) == async_response
+    assert Enum.member?(res_headers, {"foo", "bar"})
   end
 
   test_with_server "Given response_from is set to http_async and response is in binary mode, the custom http response code - 201 - is taken from the internal HTTP endpoint." do
@@ -181,19 +302,11 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     async_response = %{"message" => "this is the async response that reaches the client instead"}
 
     route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
-      event = Jason.encode!(async_response)
-
       build_conn()
+      |> put_req_header("rig-correlation", correlation_id)
+      |> put_req_header("rig-response-code", "201")
       |> put_req_header("content-type", "application/json;charset=utf-8")
-      |> put_req_header("ce-specversion", "0.2")
-      |> put_req_header("ce-type", "rig.async-response")
-      |> put_req_header("ce-source", "fake-service")
-      |> put_req_header("ce-id", "1")
-      |> put_req_header(
-        "ce-rig",
-        Jason.encode!(%{correlation: correlation_id, response_code: 201})
-      )
-      |> post("/v2/responses", event)
+      |> post("/v2/responses", Jason.encode!(async_response))
 
       Response.ok!(sync_response, %{"content-type" => "application/json"})
     end)

--- a/test/rig_tests/proxy/response_from/async_http_test.exs
+++ b/test/rig_tests/proxy/response_from/async_http_test.exs
@@ -27,267 +27,8 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     end)
   end
 
-  test_with_server "Given response_from is set to http_async, the http response is taken from the internal HTTP endpoint." do
-    test_name = "proxy-http-response-from-http-internal"
-
-    api_id = "mock-#{test_name}-api"
-    endpoint_id = "mock-#{test_name}-endpoint"
-    endpoint_path = "/#{endpoint_id}"
-    sync_response = %{"this response" => "the client never sees this response"}
-    async_response = %{"message" => "this is the async response that reaches the client instead"}
-
-    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
-      message =
-        Jason.encode!(%{
-          rig: %{correlation: correlation_id},
-          body: async_response
-        })
-
-      build_conn()
-      |> put_req_header("content-type", "application/json;charset=utf-8")
-      |> post("/v2/responses", message)
-
-      Response.ok!(sync_response, %{"content-type" => "application/json"})
-    end)
-
-    # We register the endpoint with the proxy:
-    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
-    rig_proxy_url = "http://localhost:#{@proxy_port}"
-
-    body =
-      Jason.encode!(%{
-        id: api_id,
-        name: "Mock API",
-        version_data: %{
-          default: %{
-            endpoints: [
-              %{
-                id: endpoint_id,
-                method: "GET",
-                path: endpoint_path,
-                response_from: "http_async"
-              }
-            ]
-          }
-        },
-        proxy: %{
-          target_url: "localhost",
-          port: FakeServer.port()
-        }
-      })
-
-    headers = [{"content-type", "application/json"}]
-    HTTPoison.post!(rig_api_url, body, headers)
-
-    # The client calls the proxy endpoint:
-    request_url = rig_proxy_url <> endpoint_path
-    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
-
-    # Now we can assert that...
-    # ...the fake backend service has been called:
-    assert FakeServer.hits() == 1
-    # ...the connection is closed and the status is OK:
-    assert res_status == 200
-    # ...but the client got the response sent to the HTTP internal endpoint:
-    assert Jason.decode!(res_body) == async_response
-  end
-
-  test_with_server "Given response_from is set to http_async and response is in binary mode, the http response should include only body content." do
+  test_with_server "Given response_from is set to http_async and response is in binary mode, the http response is taken from the internal HTTP endpoint." do
     test_name = "proxy-http-response-from-http-internal-binary"
-
-    api_id = "mock-#{test_name}-api"
-    endpoint_id = "mock-#{test_name}-endpoint"
-    endpoint_path = "/#{endpoint_id}"
-    sync_response = %{"this response" => "the client never sees this response"}
-    async_response = %{"message" => "this is the async response that reaches the client instead"}
-
-    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
-      build_conn()
-      |> put_req_header("rig-correlation", correlation_id)
-      |> put_req_header("content-type", "application/json;charset=utf-8")
-      |> post("/v2/responses", Jason.encode!(async_response))
-
-      Response.ok!(sync_response, %{"content-type" => "application/json"})
-    end)
-
-    # We register the endpoint with the proxy:
-    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
-    rig_proxy_url = "http://localhost:#{@proxy_port}"
-
-    body =
-      Jason.encode!(%{
-        id: api_id,
-        name: "Mock API",
-        version_data: %{
-          default: %{
-            endpoints: [
-              %{
-                id: endpoint_id,
-                method: "GET",
-                path: endpoint_path,
-                response_from: "http_async"
-              }
-            ]
-          }
-        },
-        proxy: %{
-          target_url: "localhost",
-          port: FakeServer.port()
-        }
-      })
-
-    headers = [{"content-type", "application/json"}]
-    HTTPoison.post!(rig_api_url, body, headers)
-
-    # The client calls the proxy endpoint:
-    request_url = rig_proxy_url <> endpoint_path
-    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
-
-    # Now we can assert that...
-    # ...the fake backend service has been called:
-    assert FakeServer.hits() == 1
-    # ...the connection is closed and the status is OK:
-    assert res_status == 200
-    # ...but the client got the response sent to the HTTP internal endpoint:
-    assert Jason.decode!(res_body) == async_response
-  end
-
-  test_with_server "Given response_from is set to http_async, the custom http response code - 201 - is taken from the internal HTTP endpoint." do
-    test_name = "proxy-http-response-from-http-internal-status-code"
-
-    api_id = "mock-#{test_name}-api"
-    endpoint_id = "mock-#{test_name}-endpoint"
-    endpoint_path = "/#{endpoint_id}"
-    sync_response = %{"this response" => "the client never sees this response"}
-    async_response = %{"message" => "this is the async response that reaches the client instead"}
-
-    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
-      message =
-        Jason.encode!(%{
-          rig: %{correlation: correlation_id, response_code: 201},
-          body: async_response
-        })
-
-      build_conn()
-      |> put_req_header("content-type", "application/json;charset=utf-8")
-      |> post("/v2/responses", message)
-
-      Response.ok!(sync_response, %{"content-type" => "application/json"})
-    end)
-
-    # We register the endpoint with the proxy:
-    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
-    rig_proxy_url = "http://localhost:#{@proxy_port}"
-
-    body =
-      Jason.encode!(%{
-        id: api_id,
-        name: "Mock API",
-        version_data: %{
-          default: %{
-            endpoints: [
-              %{
-                id: endpoint_id,
-                method: "GET",
-                path: endpoint_path,
-                response_from: "http_async"
-              }
-            ]
-          }
-        },
-        proxy: %{
-          target_url: "localhost",
-          port: FakeServer.port()
-        }
-      })
-
-    headers = [{"content-type", "application/json"}]
-    HTTPoison.post!(rig_api_url, body, headers)
-
-    # The client calls the proxy endpoint:
-    request_url = rig_proxy_url <> endpoint_path
-    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
-
-    # Now we can assert that...
-    # ...the fake backend service has been called:
-    assert FakeServer.hits() == 1
-    # ...the connection is closed and the status is OK:
-    assert res_status == 201
-    # ...but the client got the response sent to the HTTP internal endpoint:
-    assert Jason.decode!(res_body) == async_response
-  end
-
-  test_with_server "Given response_from is set to http_async, the provided headers are taken from the internal HTTP endpoint." do
-    test_name = "proxy-http-response-from-http-internal-headers"
-
-    api_id = "mock-#{test_name}-api"
-    endpoint_id = "mock-#{test_name}-endpoint"
-    endpoint_path = "/#{endpoint_id}"
-    sync_response = %{"this response" => "the client never sees this response"}
-    async_response = %{"message" => "this is the async response that reaches the client instead"}
-
-    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
-      message =
-        Jason.encode!(%{
-          rig: %{correlation: correlation_id, response_code: 201},
-          body: async_response,
-          headers: %{foo: "bar"}
-        })
-
-      build_conn()
-      |> put_req_header("content-type", "application/json;charset=utf-8")
-      |> post("/v2/responses", message)
-
-      Response.ok!(sync_response, %{"content-type" => "application/json"})
-    end)
-
-    # We register the endpoint with the proxy:
-    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
-    rig_proxy_url = "http://localhost:#{@proxy_port}"
-
-    body =
-      Jason.encode!(%{
-        id: api_id,
-        name: "Mock API",
-        version_data: %{
-          default: %{
-            endpoints: [
-              %{
-                id: endpoint_id,
-                method: "GET",
-                path: endpoint_path,
-                response_from: "http_async"
-              }
-            ]
-          }
-        },
-        proxy: %{
-          target_url: "localhost",
-          port: FakeServer.port()
-        }
-      })
-
-    headers = [{"content-type", "application/json"}]
-    HTTPoison.post!(rig_api_url, body, headers)
-
-    # The client calls the proxy endpoint:
-    request_url = rig_proxy_url <> endpoint_path
-
-    %HTTPoison.Response{status_code: res_status, body: res_body, headers: res_headers} =
-      HTTPoison.get!(request_url)
-
-    # Now we can assert that...
-    # ...the fake backend service has been called:
-    assert FakeServer.hits() == 1
-    # ...the connection is closed and the status is OK:
-    assert res_status == 201
-    # ...but the client got the response sent to the HTTP internal endpoint:
-    assert Jason.decode!(res_body) == async_response
-    assert Enum.member?(res_headers, {"foo", "bar"})
-  end
-
-  test_with_server "Given response_from is set to http_async and response is in binary mode, the custom http response code - 201 - is taken from the internal HTTP endpoint." do
-    test_name = "proxy-http-response-from-http-internal-binary-status-code"
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
@@ -347,8 +88,8 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     assert Jason.decode!(res_body) == async_response
   end
 
-  test_with_server "Given response_from (/v1) is set to http_async, the http response is taken from the internal HTTP endpoint." do
-    test_name = "proxy-http-response-from-http-internal-v1"
+  test_with_server "Given (v1) response_from is set to http_async and response is in binary mode, the http response  is taken from the internal HTTP endpoint." do
+    test_name = "proxy-http-response-from-http-internal-binary-v1"
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
@@ -357,15 +98,11 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     async_response = %{"message" => "this is the async response that reaches the client instead"}
 
     route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
-      message =
-        Jason.encode!(%{
-          rig: %{correlation: correlation_id},
-          body: async_response
-        })
-
       build_conn()
+      |> put_req_header("rig-correlation", correlation_id)
+      |> put_req_header("rig-response-code", "201")
       |> put_req_header("content-type", "application/json;charset=utf-8")
-      |> post("/v1/responses", message)
+      |> post("/v1/responses", Jason.encode!(async_response))
 
       Response.ok!(sync_response, %{"content-type" => "application/json"})
     end)
@@ -407,7 +144,7 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     # ...the fake backend service has been called:
     assert FakeServer.hits() == 1
     # ...the connection is closed and the status is OK:
-    assert res_status == 200
+    assert res_status == 201
     # ...but the client got the response sent to the HTTP internal endpoint:
     assert Jason.decode!(res_body) == async_response
   end

--- a/test/rig_tests/proxy/response_from/async_http_test.exs
+++ b/test/rig_tests/proxy/response_from/async_http_test.exs
@@ -87,8 +87,70 @@ defmodule RigTests.Proxy.ResponseFrom.AsyncHttpTest do
     # ...the connection is closed and the status is OK:
     assert res_status == 201
     # ...extra headers are present
-    assert Enum.member?(headers, {"content-type", "application/json; charset=utf-8"})
+    assert Enum.member?(headers, {"content-type", "application/json;charset=utf-8"})
     # ...but the client got the response sent to the HTTP internal endpoint:
     assert Jason.decode!(res_body) == async_response
+  end
+
+  test_with_server "Given response_from is set to http_async and response code is incorrect, the calling service should receive 400 and originating request should timeout." do
+    test_name = "proxy-http-response-from-http-internal-binary-timeout"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"this response" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      %Plug.Conn{status: res_status, resp_body: res_body} =
+        build_conn()
+        |> put_req_header("rig-correlation", correlation_id)
+        |> put_req_header("rig-response-code", "abc201")
+        |> put_req_header("content-type", "application/json;charset=utf-8")
+        |> post("/v3/responses", Jason.encode!(async_response))
+
+      assert res_status == 400
+      assert res_body == "Failed to parse request body: {:error, {:not_an_integer, \"abc201\"}}"
+
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v3/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                method: "GET",
+                path: endpoint_path,
+                response_from: "http_async"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+
+    assert catch_error(HTTPoison.get!(request_url)) == %HTTPoison.Error{id: nil, reason: :timeout}
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
   end
 end

--- a/test/rig_tests/proxy/response_from/http_test.exs
+++ b/test/rig_tests/proxy/response_from/http_test.exs
@@ -50,8 +50,6 @@ defmodule RigTests.Proxy.ResponseFrom.HttpTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "GET",
                 path: endpoint_path
               }

--- a/test/rig_tests/proxy/response_from/kafka_test.exs
+++ b/test/rig_tests/proxy/response_from/kafka_test.exs
@@ -130,6 +130,82 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
   end
 
   @tag :kafka
+  test_with_server "Given response_from is set to Kafka, the custom http response code - 201 - is taken from the Kafka response topic." do
+    test_name = "proxy-http-response-from-kafka-status-code"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    %{response_topic: kafka_topic} = config()
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"message" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    # The following service fake also shows how a real service should
+    # wrap its response in a CloudEvent:
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      event =
+        Jason.encode!(%{
+          specversion: "0.2",
+          type: "rig.async-response",
+          source: "fake-service",
+          id: "1",
+          rig: %{correlation: correlation_id, response_code: 201},
+          data: async_response
+        })
+
+      kafka_config = kafka_config()
+      assert :ok == RigKafka.produce(kafka_config, kafka_topic, "", "response", event)
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                type: "http",
+                secured: false,
+                method: "GET",
+                path: endpoint_path,
+                response_from: "kafka"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+
+    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
+    # ...the connection is closed and the status is OK:
+    assert res_status == 201
+    # ...the client never saw the http response:
+    assert Jason.decode!(res_body) != sync_response
+    # ...but the client got the response sent to the Kafka topic:
+    assert Jason.decode!(res_body)["data"] == async_response
+  end
+
+  @tag :kafka
   test_with_server "Given response_from is set to Kafka and response is in binary mode, the http response should include only body content." do
     test_name = "proxy-http-response-from-kafka-binary"
 
@@ -206,6 +282,87 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     assert FakeServer.hits() == 1
     # ...the connection is closed and the status is OK:
     assert res_status == 200
+    # ...but the client got the response sent to the Kafka topic:
+    assert Jason.decode!(res_body) == async_response
+  end
+
+  @tag :kafka
+  test_with_server "Given response_from is set to Kafka and response is in binary mode, the custom http response code - 201 - should be used." do
+    test_name = "proxy-http-response-from-kafka-binary-status-code"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    %{response_topic: kafka_topic} = config()
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"message" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+
+    # The following service fake also shows how a real service should
+    # wrap its response in a CloudEvent:
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      kafka_config = kafka_config()
+
+      assert :ok ==
+               RigKafka.produce(
+                 kafka_config,
+                 kafka_topic,
+                 "",
+                 "response",
+                 Jason.encode!(async_response),
+                 [
+                   {"content-type", "application/json"},
+                   {"ce_specversion", "0.2"},
+                   {"ce_type", "rig.async-response"},
+                   {"ce_source", "fake-service"},
+                   {"ce_rig", Jason.encode!(%{correlation: correlation_id, response_code: 201})},
+                   {"ce_id", "2"}
+                 ]
+               )
+
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                type: "http",
+                secured: false,
+                method: "GET",
+                path: endpoint_path,
+                response_from: "kafka"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+
+    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
+    # ...the connection is closed and the status is OK:
+    assert res_status == 201
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
   end

--- a/test/rig_tests/proxy/response_from/kafka_test.exs
+++ b/test/rig_tests/proxy/response_from/kafka_test.exs
@@ -42,20 +42,11 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     end)
   end
 
-  setup do
-    kafka_config = kafka_config()
-    {:ok, kafka_client} = RigKafka.start(kafka_config)
-
-    on_exit(fn ->
-      :ok = RigKafka.Client.stop_supervised(kafka_client)
-    end)
-
-    :ok
-  end
-
   @tag :kafka
   test_with_server "Given response_from is set to Kafka, the http response is taken from the Kafka response topic instead of forwarding the backend's original response." do
     test_name = "proxy-http-response-from-kafka"
+    kafka_config = kafka_config()
+    {:ok, kafka_client} = RigKafka.start(kafka_config)
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
@@ -91,8 +82,6 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "GET",
                 path: endpoint_path,
                 response_from: "kafka"
@@ -121,11 +110,15 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     assert res_status == 200
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
+
+    RigKafka.Client.stop_supervised(kafka_client)
   end
 
   @tag :kafka
   test_with_server "Given response_from is set to Kafka, the custom http response code - 201 - is taken from the Kafka response topic." do
     test_name = "proxy-http-response-from-kafka-status-code"
+    kafka_config = kafka_config()
+    {:ok, kafka_client} = RigKafka.start(kafka_config)
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
@@ -161,8 +154,6 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "GET",
                 path: endpoint_path,
                 response_from: "kafka"
@@ -191,11 +182,15 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     assert res_status == 201
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
+
+    RigKafka.Client.stop_supervised(kafka_client)
   end
 
   @tag :kafka
   test_with_server "Given response_from is set to Kafka and response is in binary mode, the http response should include only body content." do
     test_name = "proxy-http-response-from-kafka-binary"
+    kafka_config = kafka_config()
+    {:ok, kafka_client} = RigKafka.start(kafka_config)
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
@@ -237,8 +232,6 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "GET",
                 path: endpoint_path,
                 response_from: "kafka"
@@ -267,11 +260,15 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     assert res_status == 200
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
+
+    RigKafka.Client.stop_supervised(kafka_client)
   end
 
   @tag :kafka
   test_with_server "Given response_from is set to Kafka, the provided headers are forwarded to client." do
     test_name = "proxy-http-response-from-kafka-headers"
+    kafka_config = kafka_config()
+    {:ok, kafka_client} = RigKafka.start(kafka_config)
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
@@ -309,8 +306,6 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "GET",
                 path: endpoint_path,
                 response_from: "kafka"
@@ -341,11 +336,15 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
     assert Enum.member?(res_headers, {"foo", "bar"})
+
+    RigKafka.Client.stop_supervised(kafka_client)
   end
 
   @tag :kafka
   test_with_server "Given response_from is set to Kafka and response is in binary mode, the custom http response code - 201 - should be used." do
     test_name = "proxy-http-response-from-kafka-binary-status-code"
+    kafka_config = kafka_config()
+    {:ok, kafka_client} = RigKafka.start(kafka_config)
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
@@ -388,8 +387,6 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "GET",
                 path: endpoint_path,
                 response_from: "kafka"
@@ -418,11 +415,15 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     assert res_status == 201
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
+
+    RigKafka.Client.stop_supervised(kafka_client)
   end
 
   @tag :avro
   test_with_server "Given response_from is set to Kafka and response is in avro format, the http response should be correctly decoded and forwarded." do
     test_name = "proxy-http-response-from-kafka-avro"
+    kafka_config = kafka_config()
+    {:ok, kafka_client} = RigKafka.start(kafka_config)
 
     api_id = "mock-#{test_name}-api"
     endpoint_id = "mock-#{test_name}-endpoint"
@@ -458,6 +459,8 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
                )
 
       Response.ok!(sync_response, %{"content-type" => "application/json"})
+
+      RigKafka.Client.stop_supervised(kafka_client)
     end)
 
     # We register the endpoint with the proxy:
@@ -473,8 +476,6 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "GET",
                 path: endpoint_path,
                 response_from: "kafka"
@@ -504,5 +505,91 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     assert res_status == 200
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
+
+    RigKafka.Client.stop_supervised(kafka_client)
+  end
+
+  @tag :kafka
+  test_with_server "Given response_from and target are set to Kafka, the http response is taken from the Kafka response topic instead of forwarding the backend's original response." do
+    test_name = "proxy-http-response-from-kafka-target"
+    topic = "rig-test"
+
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+    kafka_config = kafka_config()
+
+    callback = fn
+      body, headers ->
+        {:ok, event} = Cloudevents.from_kafka_message(body, headers)
+
+        message =
+          Jason.encode!(%{
+            rig: %{correlation: get_in(event.extensions, ["rig", "correlation"]), response_code: 201},
+            body: Jason.encode!(async_response)
+          })
+
+        assert :ok == RigKafka.produce(kafka_config, config().response_topic, "", "response", message)
+    end
+
+    {:ok, kafka_client} = RigKafka.start(kafka_config, callback)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                method: "POST",
+                path: endpoint_path,
+                response_from: "kafka",
+                target: "kafka",
+                topic: topic
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+    req_body =
+      Jason.encode!(%{
+        "event" => %{
+          "specversion" => "0.2",
+          "type" => "com.example.test",
+          "source" => "/rig-test",
+          "id" => "069711bf-3946-4661-984f-c667657b8d85",
+          "time" => "2018-04-05T17:31:00Z",
+          "data" => %{
+            "foo" => "bar"
+          }
+        }
+      })
+
+    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.post!(request_url, req_body, [], recv_timeout: 30_000)
+
+    # Now we can assert that...
+    # ...the connection is closed and the status is OK:
+    assert res_status == 201
+    # ...but the client got the response sent to the Kafka topic:
+    assert Jason.decode!(res_body) == async_response
+
+    RigKafka.Client.stop_supervised(kafka_client)
   end
 end

--- a/test/rig_tests/proxy/response_from/kafka_test.exs
+++ b/test/rig_tests/proxy/response_from/kafka_test.exs
@@ -61,7 +61,7 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
       message =
         Jason.encode!(%{
           rig: %{correlation: correlation_id},
-          body: Jason.encode!(async_response)
+          body: async_response
         })
 
       kafka_config = kafka_config()
@@ -133,7 +133,7 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
       message =
         Jason.encode!(%{
           rig: %{correlation: correlation_id, response_code: 201},
-          body: Jason.encode!(async_response)
+          body: async_response
         })
 
       kafka_config = kafka_config()
@@ -283,7 +283,7 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
       message =
         Jason.encode!(%{
           rig: %{correlation: correlation_id},
-          body: Jason.encode!(async_response),
+          body: async_response,
           headers: %{foo: "bar"}
         })
 
@@ -527,7 +527,7 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
         message =
           Jason.encode!(%{
             rig: %{correlation: get_in(event.extensions, ["rig", "correlation"]), response_code: 201},
-            body: Jason.encode!(async_response)
+            body: async_response
           })
 
         assert :ok == RigKafka.produce(kafka_config, config().response_topic, "", "response", message)

--- a/test/rig_tests/proxy/response_from/kafka_test.exs
+++ b/test/rig_tests/proxy/response_from/kafka_test.exs
@@ -69,7 +69,8 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
                  Jason.encode!(async_response),
                  [
                    {"rig-correlation", correlation_id},
-                   {"rig-response-code", "201"}
+                   {"rig-response-code", "201"},
+                   {"content-type", "application/json;charset=utf-8"}
                  ]
                )
 
@@ -117,109 +118,183 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     # ...the connection is closed and the status is OK:
     assert res_status == 201
     # ...extra headers are present
-    assert Enum.member?(headers, {"content-type", "application/json; charset=utf-8"})
+    assert Enum.member?(headers, {"content-type", "application/json;charset=utf-8"})
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
 
     RigKafka.Client.stop_supervised(kafka_client)
   end
 
-  # @tag :kafka
-  # test_with_server "Given response_from and target are set to Kafka, the http response is taken from the Kafka response topic instead of forwarding the backend's original response." do
-  #   test_name = "proxy-http-response-from-kafka-target"
-  #   topic = "rig-test"
+  @tag :kafka
+  test_with_server "Given response_from is set to Kafka and response code is incorrect, the originating request should timeout." do
+    test_name = "proxy-http-response-from-kafka-binary-status-code-timeout"
+    kafka_config = kafka_config()
+    {:ok, kafka_client} = RigKafka.start(kafka_config)
 
-  #   api_id = "mock-#{test_name}-api"
-  #   endpoint_id = "mock-#{test_name}-endpoint"
-  #   endpoint_path = "/#{endpoint_id}"
-  #   async_response = %{"message" => "this is the async response that reaches the client instead"}
-  #   kafka_config = kafka_config()
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    %{response_topic: kafka_topic} = config()
+    endpoint_path = "/#{endpoint_id}"
+    sync_response = %{"message" => "the client never sees this response"}
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
 
-  #   callback = fn
-  #     body, headers ->
-  #       {:ok, event} = Cloudevents.from_kafka_message(body, headers)
+    # The following service fake also shows how a real service should
+    # wrap its response in a CloudEvent:
+    route(endpoint_path, fn %{query: %{"correlation" => correlation_id}} ->
+      kafka_config = kafka_config()
 
-  #       IO.inspect(event, label: "event")
+      assert :ok ==
+               RigKafka.produce(
+                 kafka_config,
+                 kafka_topic,
+                 "",
+                 "response",
+                 Jason.encode!(async_response),
+                 [
+                   {"rig-correlation", correlation_id},
+                   {"rig-response-code", "abc201"},
+                   {"content-type", "application/json;charset=utf-8"}
+                 ]
+               )
 
-  #       message =
-  #         Jason.encode!(%{
-  #           rig: %{correlation: get_in(event.extensions, ["rig", "correlation"]), response_code: 201},
-  #           body: async_response
-  #         })
+      Response.ok!(sync_response, %{"content-type" => "application/json"})
+    end)
 
-  #       assert :ok == RigKafka.produce(kafka_config, config().response_topic, "", "response", message)
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
 
-  #       # assert :ok ==
-  #       #   RigKafka.produce(
-  #       #     kafka_config,
-  #       #     config().response_topic,
-  #       #     "",
-  #       #     "response",
-  #       #     Jason.encode!(async_response),
-  #       #     [
-  #       #       {"rig-correlation", get_in(event.extensions, ["rig", "correlation"])},
-  #       #       {"rig-response-code", "201"}
-  #       #     ]
-  #       #   )
-  #   end
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                method: "GET",
+                path: endpoint_path,
+                response_from: "kafka"
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
 
-  #   {:ok, kafka_client} = RigKafka.start(kafka_config, callback)
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
 
-  #   # We register the endpoint with the proxy:
-  #   rig_api_url = "http://localhost:#{@api_port}/v2/apis"
-  #   rig_proxy_url = "http://localhost:#{@proxy_port}"
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
 
-  #   body =
-  #     Jason.encode!(%{
-  #       id: api_id,
-  #       name: "Mock API",
-  #       version_data: %{
-  #         default: %{
-  #           endpoints: [
-  #             %{
-  #               id: endpoint_id,
-  #               method: "POST",
-  #               path: endpoint_path,
-  #               response_from: "kafka",
-  #               target: "kafka",
-  #               topic: topic
-  #             }
-  #           ]
-  #         }
-  #       },
-  #       proxy: %{
-  #         target_url: "localhost",
-  #         port: FakeServer.port()
-  #       }
-  #     })
+    assert catch_error(HTTPoison.get!(request_url)) == %HTTPoison.Error{id: nil, reason: :timeout}
 
-  #   headers = [{"content-type", "application/json"}]
-  #   HTTPoison.post!(rig_api_url, body, headers)
+    # Now we can assert that...
+    # ...the fake backend service has been called:
+    assert FakeServer.hits() == 1
 
-  #   # The client calls the proxy endpoint:
-  #   request_url = rig_proxy_url <> endpoint_path
-  #   req_body =
-  #     Jason.encode!(%{
-  #       "event" => %{
-  #         "specversion" => "0.2",
-  #         "type" => "com.example.test",
-  #         "source" => "/rig-test",
-  #         "id" => "069711bf-3946-4661-984f-c667657b8d85",
-  #         "time" => "2018-04-05T17:31:00Z",
-  #         "data" => %{
-  #           "foo" => "bar"
-  #         }
-  #       }
-  #     })
+    RigKafka.Client.stop_supervised(kafka_client)
+  end
 
-  #   %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.post!(request_url, req_body)
+  @tag :kafka
+  test_with_server "Given response_from and target are set to Kafka, the http response is taken from the Kafka response topic instead of forwarding the backend's original response." do
+    test_name = "proxy-http-response-from-kafka-target"
+    topic = "rig-test"
 
-  #   # Now we can assert that...
-  #   # ...the connection is closed and the status is OK:
-  #   assert res_status == 201
-  #   # ...but the client got the response sent to the Kafka topic:
-  #   assert Jason.decode!(res_body) == async_response
+    api_id = "mock-#{test_name}-api"
+    endpoint_id = "mock-#{test_name}-endpoint"
+    endpoint_path = "/#{endpoint_id}"
+    async_response = %{"message" => "this is the async response that reaches the client instead"}
+    kafka_config = kafka_config()
 
-  #   RigKafka.Client.stop_supervised(kafka_client)
-  # end
+    callback = fn
+      body, headers ->
+        {:ok, event} = Cloudevents.from_kafka_message(body, headers)
+
+        assert :ok ==
+                 RigKafka.produce(
+                   kafka_config,
+                   config().response_topic,
+                   "",
+                   "response",
+                   Jason.encode!(async_response),
+                   [
+                     {"rig-correlation", get_in(event.extensions, ["rig", "correlation"])},
+                     {"rig-response-code", "201"},
+                     {"content-type", "application/json;charset=utf-8"}
+                   ]
+                 )
+    end
+
+    {:ok, kafka_client} = RigKafka.start(kafka_config, callback)
+
+    # We register the endpoint with the proxy:
+    rig_api_url = "http://localhost:#{@api_port}/v2/apis"
+    rig_proxy_url = "http://localhost:#{@proxy_port}"
+
+    body =
+      Jason.encode!(%{
+        id: api_id,
+        name: "Mock API",
+        version_data: %{
+          default: %{
+            endpoints: [
+              %{
+                id: endpoint_id,
+                method: "POST",
+                path: endpoint_path,
+                response_from: "kafka",
+                target: "kafka",
+                topic: topic
+              }
+            ]
+          }
+        },
+        proxy: %{
+          target_url: "localhost",
+          port: FakeServer.port()
+        }
+      })
+
+    headers = [{"content-type", "application/json"}]
+    HTTPoison.post!(rig_api_url, body, headers)
+
+    # The client calls the proxy endpoint:
+    request_url = rig_proxy_url <> endpoint_path
+
+    req_body =
+      Jason.encode!(%{
+        "event" => %{
+          "specversion" => "0.2",
+          "type" => "com.example.test",
+          "source" => "/rig-test",
+          "id" => "069711bf-3946-4661-984f-c667657b8d85",
+          "time" => "2018-04-05T17:31:00Z",
+          "data" => %{
+            "foo" => "bar"
+          }
+        }
+      })
+
+    # consumer start tends to be slower sometimes, therefore we give it some time before producing
+    :timer.sleep(15_000)
+
+    %HTTPoison.Response{status_code: res_status, body: res_body, headers: headers} =
+      HTTPoison.post!(request_url, req_body)
+
+    # Now we can assert that...
+    # ...the connection is closed and the status is OK:
+    assert res_status == 201
+    # ...extra headers are present
+    assert Enum.member?(headers, {"content-type", "application/json;charset=utf-8"})
+    # ...but the client got the response sent to the Kafka topic:
+    assert Jason.decode!(res_body) == async_response
+
+    RigKafka.Client.stop_supervised(kafka_client)
+  end
 end

--- a/test/rig_tests/proxy/response_from/kafka_test.exs
+++ b/test/rig_tests/proxy/response_from/kafka_test.exs
@@ -108,13 +108,16 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
     # The client calls the proxy endpoint:
     request_url = rig_proxy_url <> endpoint_path
 
-    %HTTPoison.Response{status_code: res_status, body: res_body} = HTTPoison.get!(request_url)
+    %HTTPoison.Response{status_code: res_status, body: res_body, headers: headers} =
+      HTTPoison.get!(request_url)
 
     # Now we can assert that...
     # ...the fake backend service has been called:
     assert FakeServer.hits() == 1
     # ...the connection is closed and the status is OK:
     assert res_status == 201
+    # ...extra headers are present
+    assert Enum.member?(headers, {"content-type", "application/json; charset=utf-8"})
     # ...but the client got the response sent to the Kafka topic:
     assert Jason.decode!(res_body) == async_response
 

--- a/test/rig_tests/proxy/response_from/kafka_test.exs
+++ b/test/rig_tests/proxy/response_from/kafka_test.exs
@@ -452,8 +452,9 @@ defmodule RigTests.Proxy.ResponseFrom.KafkaTest do
                  kafka_topic,
                  "rig-proxy-avro-value",
                  "response",
+                 # we are using cloud events format here since RigKafka.produce enforces it, but response_from handler will ignore that fact
                  event,
-                 []
+                 [{"rig-correlation", correlation_id}]
                )
 
       Response.ok!(sync_response, %{"content-type" => "application/json"})

--- a/test/rig_tests/proxy/response_from/kinesis_test.exs
+++ b/test/rig_tests/proxy/response_from/kinesis_test.exs
@@ -70,8 +70,6 @@ defmodule RigTests.Proxy.ResponseFrom.KinesisTest do
             endpoints: [
               %{
                 id: endpoint_id,
-                type: "http",
-                secured: false,
                 method: "GET",
                 path: endpoint_path,
                 response_from: "kinesis"

--- a/test/support/api_proxy_injection.ex
+++ b/test/support/api_proxy_injection.ex
@@ -1,7 +1,7 @@
 defmodule RigInboundGateway.ApiProxyInjection do
   @moduledoc false
 
-  @mods [RigApi.V1.APIs, RigApi.V2.APIs]
+  @mods [RigApi.V1.APIs, RigApi.V2.APIs, RigApi.V3.APIs]
   @orig_vals for mod <- @mods, do: {mod, Application.get_env(:rig, mod)}
 
   def set do

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -25,6 +25,10 @@
         "title": "Avro Implementation Details",
         "sidebar_label": "Avro"
       },
+      "distributed-tracing": {
+        "title": "Distributed Tracing",
+        "sidebar_label": "Distributed Tracing"
+      },
       "event-format": {
         "title": "Event Format",
         "sidebar_label": "Event Format"


### PR DESCRIPTION
## Description

Support custom response code for these `response_from` targets:

- [x] Kafka
- [x] HTTP async
- [-] ~~NATS~~ - NATS -> NATS not implemented as I wasn't able to test it properly
- [-] ~~Kinesis~~ - Not supported atm

## What to look out for

- tests should cover majority of cases and docs should reflect the proper usage/state

Closes https://github.com/Accenture/reactive-interaction-gateway/issues/221
