### PR TITLE
make github pages url Accenture upper-case as helm can't handle it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish Helm Chart to Github pages. With this change, we can simply install the chart using
 
     ```shell
-    helm repo add accenture https://accenture.github.io/reactive-interaction-gateway
+    helm repo add accenture https://Accenture.github.io/reactive-interaction-gateway
     helm install rig accenture/reactive-interaction-gateway
     ```
   

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -3,7 +3,7 @@
 The easiest way to deploy RIG is using Helm:
 
 ```shell
-helm repo add accenture https://accenture.github.io/reactive-interaction-gateway
+helm repo add accenture https://Accenture.github.io/reactive-interaction-gateway
 # Helm v3
 helm install rig accenture/reactive-interaction-gateway
 # Helm v2

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -20,7 +20,7 @@ Even though it's possible to run RIG anywhere, we recommend to use Kubernetes.
 kubectl scale deployment/reactive-interaction-gateway --replicas 3
 
 # Start right away with 3 nodes using Helm template -- (assuming you are in the deployment directory)
-helm repo add accenture https://accenture.github.io/reactive-interaction-gateway
+helm repo add accenture https://Accenture.github.io/reactive-interaction-gateway
 # Helm v3
 helm install --set replicaCount=3 rig accenture/reactive-interaction-gateway
 # Helm v2


### PR DESCRIPTION
## Description

This does not work:

```shell
helm repo add accenture https://accenture.github.io/reactive-interaction-gateway
```

but this works:

```shell
helm repo add accenture https://Accenture.github.io/reactive-interaction-gateway
```

:man_facepalming:
