### PR TITLE
FIX: Restore helm repo index file in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ jobs:
         - git config --global user.email "${GH_EMAIL}"
         - echo "machine github.com login ${GH_NAME} password ${GH_TOKEN}" > ~/.netrc
         - cd website && yarn install && GIT_USER="${GH_NAME}" yarn run publish-gh-pages
+        - git checkout gh-pages && git checkout $(git rev-list -n1 HEAD -- index.yaml)~1 -- index.yaml && git add index.yaml && git commit -m "Auto-restore Helm chart repo index after Docusaurus publish" && git push --verbose
     - stage: sourcedocs
       <<: *elixir-env
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish Helm Chart to Github pages. With this change, we can simply install the chart using
 
     ```shell
-    helm repo add accenture https://Accenture.github.io/reactive-interaction-gateway
+    helm repo add accenture https://accenture.github.io/reactive-interaction-gateway
     helm install rig accenture/reactive-interaction-gateway
     ```
   

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -3,7 +3,7 @@
 The easiest way to deploy RIG is using Helm:
 
 ```shell
-helm repo add accenture https://Accenture.github.io/reactive-interaction-gateway
+helm repo add accenture https://accenture.github.io/reactive-interaction-gateway
 # Helm v3
 helm install rig accenture/reactive-interaction-gateway
 # Helm v2

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -20,7 +20,7 @@ Even though it's possible to run RIG anywhere, we recommend to use Kubernetes.
 kubectl scale deployment/reactive-interaction-gateway --replicas 3
 
 # Start right away with 3 nodes using Helm template -- (assuming you are in the deployment directory)
-helm repo add accenture https://Accenture.github.io/reactive-interaction-gateway
+helm repo add accenture https://accenture.github.io/reactive-interaction-gateway
 # Helm v3
 helm install --set replicaCount=3 rig accenture/reactive-interaction-gateway
 # Helm v2


### PR DESCRIPTION
## Description

Docusaurus deletes everything in [the `gh-pages` branch before creating the doc files](https://github.com/facebook/docusaurus/blob/7cc44823eb1ddee1bcb0c4e37c96d4ab45ce7cd6/packages/docusaurus/src/commands/deploy.ts#L139). This can be seen [here](https://github.com/Accenture/reactive-interaction-gateway/commit/8a2deda5fe86c77181c158e2da423fc34b63905a).

This pr restores this `index.yaml` file.