### PR TITLE
334 fix endpoint validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug where distributed set processes would crash when one of their peers has died but hasn't been removed yet from the pg2 group.
+- Fixed wrong endpoint validation for reverse proxy. Now it should correctly check for `path` or `path_regex`. Before it would require `path` even with `path_regex` in place. [#334](https://github.com/Accenture/reactive-interaction-gateway/issues/334)
 
 <!-- ### Deprecated -->
 

--- a/lib/rig_api/v1/apis_test.exs
+++ b/lib/rig_api/v1/apis_test.exs
@@ -367,10 +367,7 @@ defmodule RigApi.V1.APIsTest do
                "invalid-config/" => [
                  %{"id" => "must be string"},
                  %{"id" => "must have a length of at least 1"},
-                 %{"path" => "must be string"},
-                 %{"path" => "must have a length of at least 1"},
-                 %{"path_regex" => "must be string"},
-                 %{"path_regex" => "must have a length of at least 1"},
+                 %{"path, path_regex" => "Either path or path_regex must be set"},
                  %{"method" => "must be string"},
                  %{"method" => "must have a length of at least 1"}
                ]

--- a/lib/rig_api/v1/apis_test.exs
+++ b/lib/rig_api/v1/apis_test.exs
@@ -374,6 +374,67 @@ defmodule RigApi.V1.APIsTest do
              }
     end
 
+    test "should return 400 when 'endpoint' has 'path' and 'path_regex' set at the same time" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/",
+          "path_regex" => "/"
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v1/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path, path_regex" => "You can't set path and path_regex at the same time"}
+               ]
+             }
+    end
+
+    test "should return 400 when when 'path' is set, but incorrect" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => ""
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v1/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path" => "must have a length of at least 1"}
+               ]
+             }
+    end
+
+    test "should return 400 when when 'path_regex' is set, but incorrect" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path_regex" => ""
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v1/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path_regex" => "must have a length of at least 1"}
+               ]
+             }
+    end
+
     test "should return 400 when target is set to kafka or kinesis, but topic is not" do
       # kinesis topic not set
       endpoints = [

--- a/lib/rig_api/v1/apis_test.exs
+++ b/lib/rig_api/v1/apis_test.exs
@@ -357,7 +357,7 @@ defmodule RigApi.V1.APIsTest do
              }
     end
 
-    test "should return 400 when 'endpoint' doesn't have required properties 'id', 'method' and 'path'" do
+    test "should return 400 when 'endpoint' doesn't have required properties 'id', 'method' and 'path' or 'path_regex'" do
       endpoints = [%{}]
       new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
       conn = build_conn() |> put("/v1/apis/#{@invalid_config_id}", new_api)
@@ -369,6 +369,8 @@ defmodule RigApi.V1.APIsTest do
                  %{"id" => "must have a length of at least 1"},
                  %{"path" => "must be string"},
                  %{"path" => "must have a length of at least 1"},
+                 %{"path_regex" => "must be string"},
+                 %{"path_regex" => "must have a length of at least 1"},
                  %{"method" => "must be string"},
                  %{"method" => "must have a length of at least 1"}
                ]

--- a/lib/rig_api/v2/apis_test.exs
+++ b/lib/rig_api/v2/apis_test.exs
@@ -367,10 +367,7 @@ defmodule RigApi.V2.APIsTest do
                "invalid-config/" => [
                  %{"id" => "must be string"},
                  %{"id" => "must have a length of at least 1"},
-                 %{"path" => "must be string"},
-                 %{"path" => "must have a length of at least 1"},
-                 %{"path_regex" => "must be string"},
-                 %{"path_regex" => "must have a length of at least 1"},
+                 %{"path, path_regex" => "Either path or path_regex must be set"},
                  %{"method" => "must be string"},
                  %{"method" => "must have a length of at least 1"}
                ]

--- a/lib/rig_api/v2/apis_test.exs
+++ b/lib/rig_api/v2/apis_test.exs
@@ -374,6 +374,67 @@ defmodule RigApi.V2.APIsTest do
              }
     end
 
+    test "should return 400 when 'endpoint' has 'path' and 'path_regex' set at the same time" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/",
+          "path_regex" => "/"
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v2/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path, path_regex" => "You can't set path and path_regex at the same time"}
+               ]
+             }
+    end
+
+    test "should return 400 when when 'path' is set, but incorrect" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => ""
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v2/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path" => "must have a length of at least 1"}
+               ]
+             }
+    end
+
+    test "should return 400 when when 'path_regex' is set, but incorrect" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path_regex" => ""
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v2/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path_regex" => "must have a length of at least 1"}
+               ]
+             }
+    end
+
     test "should return 400 when target is set to kafka or kinesis, but topic is not" do
       # kinesis topic not set
       endpoints = [

--- a/lib/rig_api/v2/apis_test.exs
+++ b/lib/rig_api/v2/apis_test.exs
@@ -357,7 +357,7 @@ defmodule RigApi.V2.APIsTest do
              }
     end
 
-    test "should return 400 when 'endpoint' doesn't have required properties 'id', 'method' and 'path'" do
+    test "should return 400 when 'endpoint' doesn't have required properties 'id', 'method' and 'path' or 'path_regex'" do
       endpoints = [%{}]
       new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
       conn = build_conn() |> put("/v2/apis/#{@invalid_config_id}", new_api)
@@ -369,6 +369,8 @@ defmodule RigApi.V2.APIsTest do
                  %{"id" => "must have a length of at least 1"},
                  %{"path" => "must be string"},
                  %{"path" => "must have a length of at least 1"},
+                 %{"path_regex" => "must be string"},
+                 %{"path_regex" => "must have a length of at least 1"},
                  %{"method" => "must be string"},
                  %{"method" => "must have a length of at least 1"}
                ]

--- a/lib/rig_api/v3/apis_test.exs
+++ b/lib/rig_api/v3/apis_test.exs
@@ -367,10 +367,7 @@ defmodule RigApi.V3.APIsTest do
                "invalid-config/" => [
                  %{"id" => "must be string"},
                  %{"id" => "must have a length of at least 1"},
-                 %{"path" => "must be string"},
-                 %{"path" => "must have a length of at least 1"},
-                 %{"path_regex" => "must be string"},
-                 %{"path_regex" => "must have a length of at least 1"},
+                 %{"path, path_regex" => "Either path or path_regex must be set"},
                  %{"method" => "must be string"},
                  %{"method" => "must have a length of at least 1"}
                ]

--- a/lib/rig_api/v3/apis_test.exs
+++ b/lib/rig_api/v3/apis_test.exs
@@ -357,7 +357,7 @@ defmodule RigApi.V3.APIsTest do
              }
     end
 
-    test "should return 400 when 'endpoint' doesn't have required properties 'id', 'method' and 'path'" do
+    test "should return 400 when 'endpoint' doesn't have required properties 'id', 'method' and 'path' or 'path_regex'" do
       endpoints = [%{}]
       new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
       conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
@@ -369,6 +369,8 @@ defmodule RigApi.V3.APIsTest do
                  %{"id" => "must have a length of at least 1"},
                  %{"path" => "must be string"},
                  %{"path" => "must have a length of at least 1"},
+                 %{"path_regex" => "must be string"},
+                 %{"path_regex" => "must have a length of at least 1"},
                  %{"method" => "must be string"},
                  %{"method" => "must have a length of at least 1"}
                ]

--- a/lib/rig_api/v3/apis_test.exs
+++ b/lib/rig_api/v3/apis_test.exs
@@ -374,6 +374,67 @@ defmodule RigApi.V3.APIsTest do
              }
     end
 
+    test "should return 400 when 'endpoint' has 'path' and 'path_regex' set at the same time" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/",
+          "path_regex" => "/"
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path, path_regex" => "You can't set path and path_regex at the same time"}
+               ]
+             }
+    end
+
+    test "should return 400 when when 'path' is set, but incorrect" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => ""
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path" => "must have a length of at least 1"}
+               ]
+             }
+    end
+
+    test "should return 400 when when 'path_regex' is set, but incorrect" do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path_regex" => ""
+        }
+      ]
+
+      new_api = ProxyConfig.create_proxy_config(@invalid_config_id, endpoints)
+      conn = build_conn() |> put("/v3/apis/#{@invalid_config_id}", new_api)
+      response = json_response(conn, 400)
+
+      assert response == %{
+               "invalid-config/invalid-config1" => [
+                 %{"path_regex" => "must have a length of at least 1"}
+               ]
+             }
+    end
+
     test "should return 400 when target is set to kafka or kinesis, but topic is not" do
       # kinesis topic not set
       endpoints = [

--- a/lib/rig_inbound_gateway/api_proxy/validations.ex
+++ b/lib/rig_inbound_gateway/api_proxy/validations.ex
@@ -92,7 +92,7 @@ defmodule RigInboundGateway.ApiProxy.Validations do
   def validate_endpoint_path(endpoint) do
     errors = validate_string(endpoint, "path") ++ validate_string(endpoint, "path_regex")
 
-    # each option can produce 2 errors, so 4 in total, therefore 2 is min the min value for number of errors
+    # each option can produce 2 errors, so 4 in total, therefore 2 is the min value for number of errors
     with_any_error(errors, 2)
   end
 

--- a/test/rig_inbound_gateway/rig/proxy_test.exs
+++ b/test/rig_inbound_gateway/rig/proxy_test.exs
@@ -154,7 +154,68 @@ defmodule RigInboundGateway.ProxyTest do
 
       test_proxy_exit(
         ctx,
-        "[{\"invalid-config/\", [{:error, \"id\", :by, \"must be string\"}, {:error, \"id\", :length, \"must have a length of at least 1\"}, {:error, \"path\", :by, \"must be string\"}, {:error, \"path\", :length, \"must have a length of at least 1\"}, {:error, \"path_regex\", :by, \"must be string\"}, {:error, \"path_regex\", :length, \"must have a length of at least 1\"}, {:error, \"method\", :by, \"must be string\"}, {:error, \"method\", :length, \"must have a length of at least 1\"}]}]"
+        "[{\"invalid-config/\", [{:error, \"id\", :by, \"must be string\"}, {:error, \"id\", :length, \"must have a length of at least 1\"}, {:error, \"path, path_regex\", :by, \"Either path or path_regex must be set\"}, {:error, \"method\", :by, \"must be string\"}, {:error, \"method\", :length, \"must have a length of at least 1\"}]}]"
+      )
+
+      ProxyConfig.restore()
+    end
+
+    test "should exit the process when 'endpoint' has 'path' and 'path_regex' set at the same time",
+         ctx do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => "/",
+          "path_regex" => "/"
+        }
+      ]
+
+      ProxyConfig.set_proxy_config(@invalid_config_id, endpoints)
+
+      test_proxy_exit(
+        ctx,
+        "[{\"invalid-config/invalid-config1\", [{:error, \"path, path_regex\", :by, \"You can't set path and path_regex at the same time\"}]}]"
+      )
+
+      ProxyConfig.restore()
+    end
+
+    test "should exit the process when 'path' is set, but incorrect",
+         ctx do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path" => ""
+        }
+      ]
+
+      ProxyConfig.set_proxy_config(@invalid_config_id, endpoints)
+
+      test_proxy_exit(
+        ctx,
+        "[{\"invalid-config/invalid-config1\", [{:error, \"path\", :length, \"must have a length of at least 1\"}]}]"
+      )
+
+      ProxyConfig.restore()
+    end
+
+    test "should exit the process when 'path_regex' is set, but incorrect",
+         ctx do
+      endpoints = [
+        %{
+          "id" => @invalid_config_id <> "1",
+          "method" => "GET",
+          "path_regex" => ""
+        }
+      ]
+
+      ProxyConfig.set_proxy_config(@invalid_config_id, endpoints)
+
+      test_proxy_exit(
+        ctx,
+        "[{\"invalid-config/invalid-config1\", [{:error, \"path_regex\", :length, \"must have a length of at least 1\"}]}]"
       )
 
       ProxyConfig.restore()

--- a/test/rig_inbound_gateway/rig/proxy_test.exs
+++ b/test/rig_inbound_gateway/rig/proxy_test.exs
@@ -144,7 +144,7 @@ defmodule RigInboundGateway.ProxyTest do
       ProxyConfig.restore()
     end
 
-    test "should exit the process when 'endpoint' doesn't have required properties 'id', 'method' and 'path'",
+    test "should exit the process when 'endpoint' doesn't have required properties 'id', 'method' and 'path' or 'path_regex'",
          ctx do
       endpoints = [
         %{}
@@ -154,7 +154,7 @@ defmodule RigInboundGateway.ProxyTest do
 
       test_proxy_exit(
         ctx,
-        "[{\"invalid-config/\", [{:error, \"id\", :by, \"must be string\"}, {:error, \"id\", :length, \"must have a length of at least 1\"}, {:error, \"path\", :by, \"must be string\"}, {:error, \"path\", :length, \"must have a length of at least 1\"}, {:error, \"method\", :by, \"must be string\"}, {:error, \"method\", :length, \"must have a length of at least 1\"}]}]"
+        "[{\"invalid-config/\", [{:error, \"id\", :by, \"must be string\"}, {:error, \"id\", :length, \"must have a length of at least 1\"}, {:error, \"path\", :by, \"must be string\"}, {:error, \"path\", :length, \"must have a length of at least 1\"}, {:error, \"path_regex\", :by, \"must be string\"}, {:error, \"path_regex\", :length, \"must have a length of at least 1\"}, {:error, \"method\", :by, \"must be string\"}, {:error, \"method\", :length, \"must have a length of at least 1\"}]}]"
       )
 
       ProxyConfig.restore()
@@ -329,6 +329,11 @@ defmodule RigInboundGateway.ProxyTest do
           "method" => "GET",
           "secured" => false,
           "path" => "/foo"
+        },
+        %{
+          "id" => id <> "2",
+          "method" => "GET",
+          "path_regex" => "/foo/([^/]+)/bar/([^/]+)"
         }
       ]
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -45,6 +45,11 @@ defmodule RigApi.ConnCase do
                 "method" => "GET",
                 "secured" => false,
                 "path" => "/myapi/movies"
+              },
+              %{
+                "id" => "get-movies-2",
+                "method" => "GET",
+                "path_regex" => "/foo/([^/]+)/bar/([^/]+)"
               }
             ]
           }


### PR DESCRIPTION
## Description

Closes #334 

- fixed proxy endpoint validation to not require `path` when `path_regex` is set

## What to look out for

Dear reviewer, I want you to

- gain knowledge - I think it's important for you to know about the change.
- check that the code works on your machine.
- suggest implementation-code design/structure/readability improvements.
- suggest test-code design/structure/readability improvements.
- suggest documentation improvements.
- suggest language/writing improvements.
- help to find bugs (described below!).

You can try to run RIG with this (on this branch vs master branch):

```
PROXY_CONFIG_FILE='[{"id":"my-service","name":"my-service","version_data":{"default":{"endpoints":[{"id":"my-endpoint","method":"GET","path":"/","path_replacement":"/different-endpoint"},{"id":"my-transformed-endpoint","method":"GET","path_regex":"/foo/([^/]+)/bar/([^/]+)","path_replacement":"/bar/\\1/foo/\\2"}]}},"proxy":{"use_env":true,"target_url":"API_HOST","port":7070}}]' \
mix phx.server
```

## Process

The goal is to improve not only the code in this PR but also our skills! The "rules":

- The review is considered "done" as soon as all reviewers have added their review, and all their comments have been addressed.
- For knowledge-sharing reviews, each reviewer should "approve" the PR after studying its content.
- After the approval, the merge is concluded by the developer.

Have fun!
