### PR TITLE
Update to Elixir 1.11.3, OTP 23.2.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.1.2
-elixir 1.11.2-otp-23
+erlang 23.2.2
+elixir 1.11.3-otp-23

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ stages:
 
 .elixir-env: &elixir-env
   language: elixir
-  elixir: "1.11"
-  otp_release: "23.0"
+  elixir: "1.11.3"
+  otp_release: "23.2.2"
 
 jobs:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - `"path": "/foo"` -> `"path_regex": "/foo"`
       - `"path": "/foo/{id}"` -> `"path_regex": "/foo/(.+)"` - or pretty much whatever regex you need (e.g. UUID pattern)
 
-<!-- ### Security -->
+### Security
+
+- Update to Erlang/OTP 23.2.2, which fixes a critical TLS certificate
+  verification issue.
 
 ### Technical Improvements
 


### PR DESCRIPTION
Update to Erlang/OTP 23.2.2, which fixes a critical TLS certificate verification issue.