### PR TITLE
Added support for array of values in JWT claims in auto-subscription

### DIFF
--- a/lib/rig/subscriptions/parser/jwt.ex
+++ b/lib/rig/subscriptions/parser/jwt.ex
@@ -52,6 +52,13 @@ defmodule RIG.Subscriptions.Parser.JWT do
     end
     |> Result.filter_and_unwrap()
     |> Enum.into(%{})
+    |> Enum.map(fn {key, value} ->
+         cond do
+           is_list(value) -> Enum.map(value, fn element -> %{key => element} end)
+           is_bitstring(value) -> [%{key => value}]
+         end
+       end)
+    |> Enum.flat_map(& &1)
     |> List.wrap()
   end
 


### PR DESCRIPTION
## Description

> Attempting to fix issue #381 @kevinbader 
>
> This change checks for the claims value type. If the JWT claim value from the json_pointer is an array of strings(E.g. {Roles: ["Administrator", "User"]}), it will construct a subscription with multiple entries(E.g. {...,"oneOf":[{"userType":"Administrator"},{"userType":"User"}]}],...}).

