### PR TITLE
Close Kafka Single topic code block in /docs/event-streams.md

### DIFF
--- a/docs/event-streams.md
+++ b/docs/event-streams.md
@@ -87,6 +87,7 @@ docker run \
 -e KAFKA_SOURCE_TOPICS=my-topic \
 -e PROXY_KAFKA_RESPONSE_TOPICS=my-proxy-topic \
 accenture/reactive-interaction-gateway
+```
 
 As described in the [Event Format](event-format#kafka-transport-binding) Section, the Kafka consumer supports both structured and binary modes, each with JSON as well as Avro encoding (with details described in the [advanced guide on Avro](avro)).
 


### PR DESCRIPTION
Closes the "Change topics" (Single topic) code block.